### PR TITLE
feat: 기수에 따른 모든 주차 Sessions 조회

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/domain/gateway/SessionGateway.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/gateway/SessionGateway.kt
@@ -10,4 +10,6 @@ interface SessionGateway {
     fun delete(sessionId: String)
 
     fun getById(sessionId: String): Session
+
+    fun findAllByGeneration(generation: Int): List<Session>
 }

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/ViewSessions.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/ViewSessions.kt
@@ -1,0 +1,16 @@
+package com.depromeet.makers.domain.usecase
+
+import com.depromeet.makers.domain.gateway.SessionGateway
+import com.depromeet.makers.domain.model.Session
+
+class ViewSessions(
+    private val sessionGateway: SessionGateway,
+) : UseCase<ViewSessions.ViewSessionsInput, List<Session>> {
+    data class ViewSessionsInput(
+        val generation: Int,
+    )
+
+    override fun execute(input: ViewSessionsInput): List<Session> {
+        return sessionGateway.findAllByGeneration(input.generation).sortedBy { it.week }
+    }
+}

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/db/repository/JpaSessionRepository.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/db/repository/JpaSessionRepository.kt
@@ -4,7 +4,7 @@ import com.depromeet.makers.infrastructure.db.entity.SessionEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface JpaSessionRepository : JpaRepository<SessionEntity, String> {
-    fun findByGenerationAndWeek(generation: Int, week: Int): List<SessionEntity>
-
     fun existsByGenerationAndWeek(generation: Int, week: Int): Boolean
+
+    fun findAllByGeneration(generation: Int): List<SessionEntity>
 }

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/gateway/SessionGatewayImpl.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/gateway/SessionGatewayImpl.kt
@@ -30,4 +30,10 @@ class SessionGatewayImpl(
     override fun delete(sessionId: String) {
         jpaSessionRepository.deleteById(sessionId)
     }
+
+    override fun findAllByGeneration(generation: Int): List<Session> {
+        return jpaSessionRepository
+            .findAllByGeneration(generation)
+            .map { it.toDomain() }
+    }
 }

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/ViewSessionsController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/ViewSessionsController.kt
@@ -1,0 +1,39 @@
+package com.depromeet.makers.presentation.restapi.controller
+
+import com.depromeet.makers.domain.usecase.ViewSessions
+import com.depromeet.makers.presentation.restapi.dto.request.ViewSessionsRequest
+import com.depromeet.makers.presentation.restapi.dto.response.ViewSessionsResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "세션 관련 API", description = "세션의 정보를 관리하는 API")
+@RestController
+@RequestMapping("/v1/sessions")
+class ViewSessionsController(
+    private val viewSessions: ViewSessions,
+) {
+    @Operation(summary = "기수에 따른 모든 주차의 세션들 조회 요청", description = "기수에 따른 모든 주차의 세션들을 조회합니다.")
+    @PreAuthorize("hasRole('MEMBER')")
+    @GetMapping
+    @ResponseBody
+    fun viewSessions(
+        @Valid request: ViewSessionsRequest,
+    ): ViewSessionsResponse {
+        val sessions = viewSessions.execute(
+            ViewSessions.ViewSessionsInput(
+                generation = request.generation,
+            )
+        ).map { ViewSessionsResponse.SessionResponse.fromDomain(it) }
+
+        return ViewSessionsResponse(
+            generation = request.generation,
+            sessions = sessions,
+        )
+    }
+}

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/ViewSessionsController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/ViewSessionsController.kt
@@ -4,12 +4,12 @@ import com.depromeet.makers.domain.usecase.ViewSessions
 import com.depromeet.makers.presentation.restapi.dto.request.ViewSessionsRequest
 import com.depromeet.makers.presentation.restapi.dto.response.ViewSessionsResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "세션 관련 API", description = "세션의 정보를 관리하는 API")
@@ -19,9 +19,9 @@ class ViewSessionsController(
     private val viewSessions: ViewSessions,
 ) {
     @Operation(summary = "기수에 따른 모든 주차의 세션들 조회 요청", description = "기수에 따른 모든 주차의 세션들을 조회합니다.")
+    @Parameter(name = "generation", description = "조회할 세션의 기수", example = "15")
     @PreAuthorize("hasRole('MEMBER')")
     @GetMapping
-    @ResponseBody
     fun viewSessions(
         @Valid request: ViewSessionsRequest,
     ): ViewSessionsResponse {

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/request/ViewSessionsRequest.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/request/ViewSessionsRequest.kt
@@ -1,0 +1,10 @@
+package com.depromeet.makers.presentation.restapi.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "기수에 따른 모든 주차의 세션들 조회 요청")
+data class ViewSessionsRequest(
+
+    @Schema(description = "조회할 세션의 기수", example = "15")
+    val generation: Int,
+)

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/ViewSessionsResponse.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/ViewSessionsResponse.kt
@@ -1,0 +1,68 @@
+package com.depromeet.makers.presentation.restapi.dto.response
+
+import com.depromeet.makers.domain.model.Place
+import com.depromeet.makers.domain.model.Session
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "기수에 따른 모든 주차의 세션들 조회 응답 DTO")
+data class ViewSessionsResponse(
+    @Schema(description = "기수", example = "15")
+    val generation: Int,
+
+    @Schema(description = "세션 목록")
+    val sessions: List<SessionResponse>,
+) {
+    data class SessionResponse(
+        @Schema(description = "세션 ID", example = "01HWPNRE5TS9S7VC99WPETE5KE")
+        val sessionId: String,
+
+        @Schema(description = "주차", example = "1")
+        val week: Int,
+
+        @Schema(description = "세션 제목", example = "오리엔테이션")
+        val title: String,
+
+        @Schema(description = "시작 시간", example = "2021-10-01T19:00:00")
+        val startTime: String,
+
+        @Schema(description = "세션 타입", example = "ONLINE")
+        val sessionType: String,
+
+        @Schema(description = "장소", example = "온라인")
+        val place: PlaceResponse,
+    ) {
+        companion object {
+            fun fromDomain(session: Session) = with(session) {
+                SessionResponse(
+                    sessionId = sessionId,
+                    week = week,
+                    title = title,
+                    startTime = startTime.toString(),
+                    sessionType = sessionType.name,
+                    place = place.let { PlaceResponse.fromDomain(it) },
+                )
+            }
+        }
+
+        data class PlaceResponse(
+            @Schema(description = "장소 이름", example = "전북 익산시 부송동 100")
+            val address: String,
+
+            @Schema(description = "위도", example = "35.9418")
+            val latitude: Double,
+
+            @Schema(description = "경도", example = "35.9418")
+            val longitude: Double,
+        ) {
+            companion object {
+                fun fromDomain(place: Place) = with(place) {
+                    PlaceResponse(
+                        address = address,
+                        latitude = latitude,
+                        longitude = longitude,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/ViewSessionsTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/ViewSessionsTest.kt
@@ -1,0 +1,49 @@
+package com.depromeet.makers.domain.usecase
+
+import com.depromeet.makers.domain.gateway.SessionGateway
+import com.depromeet.makers.domain.model.Place
+import com.depromeet.makers.domain.model.Session
+import com.depromeet.makers.domain.model.SessionType
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+
+class ViewSessionsTest : BehaviorSpec({
+    Given("기수 별 세션을 모두 조회할 때") {
+        val sessionGateway = mockk<SessionGateway>()
+        val viewSessions = ViewSessions(sessionGateway)
+
+        val mockShuffledSessionList = (1..16).map { week ->
+            Session(
+                sessionId = "123e4567-e89b-12d3-a456-426614174000",
+                generation = 15,
+                week = week,
+                title = "세션 제목",
+                description = "세션 설명",
+                startTime = LocalDateTime.of(2030, 10, 1, 10, 0),
+                sessionType = SessionType.OFFLINE,
+                place = Place.emptyPlace(),
+                attendanceMemberIds = emptySet(),
+            )
+        }.toList().shuffled()
+
+        every { sessionGateway.findAllByGeneration(any()) } returns mockShuffledSessionList
+
+        When("execute가 실행되면") {
+            val result = viewSessions.execute(
+                ViewSessions.ViewSessionsInput(
+                    generation = 15,
+                )
+            )
+
+            Then("16주차 세션 정보가 반환된다") {
+                result.size shouldBe 16
+            }
+            Then("주차별로 정렬되어 반환된다.") {
+                result shouldBe mockShuffledSessionList.sortedBy { it.week }
+            }
+        }
+    }
+})


### PR DESCRIPTION
# 💡 기능 
- `generation` 기수에 따라 모든 주차의 세션을 조회

# 🔎 기타
- 컨트롤러 부분은 나중에 묶어도 좋을 것 같아요! 일단은 급해서 api위주로 쳐내보겠습니당

Close #10 