### PR TITLE
feat: 나의 출석 정보 조회

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/domain/gateway/AttendanceGateway.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/gateway/AttendanceGateway.kt
@@ -6,4 +6,6 @@ interface AttendanceGateway {
     fun save(attendance: Attendance): Attendance
 
     fun findByMemberIdAndGenerationAndWeek(memberId: String, generation: Int, week: Int): Attendance
+
+    fun findAllByMemberIdAndGeneration(memberId: String, generation: Int): List<Attendance>
 }

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/GetMemberAttendances.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/GetMemberAttendances.kt
@@ -1,0 +1,34 @@
+package com.depromeet.makers.domain.usecase
+
+import com.depromeet.makers.domain.gateway.AttendanceGateway
+import com.depromeet.makers.domain.gateway.MemberGateway
+import com.depromeet.makers.domain.model.Attendance
+
+class GetMemberAttendances(
+    private val attendanceGateway: AttendanceGateway,
+    private val memberGateway: MemberGateway,
+) : UseCase<GetMemberAttendances.GetMemberAttendancesInput, List<Attendance>> {
+    data class GetMemberAttendancesInput(
+        val memberId: String,
+        val generation: Int,
+    )
+
+    override fun execute(input: GetMemberAttendancesInput): List<Attendance> {
+        val member = memberGateway.getById(input.memberId)
+
+        val attendances = attendanceGateway.findAllByMemberIdAndGeneration(member.memberId, input.generation)
+            .associate { it.week to it }
+            .toMutableMap()
+
+        (1..16).filter { week -> !attendances.contains(week) }
+            .forEach { week ->
+                attendances[week] = Attendance.newAttendance(
+                    member = member,
+                    generation = input.generation,
+                    week = week,
+                )
+            }
+
+        return attendances.values.sortedBy { it.week }
+    }
+}

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/db/repository/JpaAttendanceRepository.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/db/repository/JpaAttendanceRepository.kt
@@ -10,4 +10,6 @@ interface JpaAttendanceRepository : JpaRepository<AttendanceEntity, String> {
     fun findAllByGenerationAndWeek(generation: Int, week: Int): List<AttendanceEntity>
 
     fun findByMemberIdAndGenerationAndWeek(memberId: String, generation: Int, week: Int): AttendanceEntity?
+
+    fun findAllByMemberIdAndGeneration(memberId: String, generation: Int): List<AttendanceEntity>
 }

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/gateway/AttendanceGatewayImpl.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/gateway/AttendanceGatewayImpl.kt
@@ -28,4 +28,10 @@ class AttendanceGatewayImpl(
             ?.toDomain()
             ?: throw NoSuchElementException("해당하는 회원의 세대, 주차 출석 정보가 없습니다.")
     }
+
+    override fun findAllByMemberIdAndGeneration(memberId: String, generation: Int): List<Attendance> {
+        return jpaAttendanceRepository
+            .findAllByMemberIdAndGeneration(memberId, generation)
+            .map { it.toDomain() }
+    }
 }

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/config/WebSecurityConfig.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/config/WebSecurityConfig.kt
@@ -24,7 +24,7 @@ class WebSecurityConfig {
         jwtTokenProvider: JWTTokenProvider,
         handlerExceptionResolver: HandlerExceptionResolver,
     ): SecurityFilterChain = httpSecurity
-        .securityMatcher("/v1/members/**")
+        .securityMatcher("/v1/me/**", "/v1/sessions/**", "/v1/members/**", "/v1/attendances/**", "/v1/check-in")
         .csrf { it.disable() }
         .sessionManagement {
             it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/AttendanceController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/AttendanceController.kt
@@ -1,0 +1,39 @@
+package com.depromeet.makers.presentation.restapi.controller
+
+import com.depromeet.makers.domain.usecase.GetMemberAttendances
+import com.depromeet.makers.presentation.restapi.dto.response.AttendanceResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+
+@Tag(name = "출석 관리 API", description = "출석 관리 API")
+@RestController
+@RequestMapping("/v1/attendances")
+class AttendanceController(
+    private val getMemberAttendances: GetMemberAttendances,
+) {
+
+    @PreAuthorize("hasAnyRole('MEMBER', 'ORGANIZER')")
+    @Operation(summary = "나의 출석 현황 조회", description = "로그인한 사용자의 출석 현황을 조회합니다.")
+    @GetMapping("/me")
+    fun getMyAttendance(
+        authentication: Authentication,
+        @RequestParam(defaultValue = "15") generation: Int,
+    ): List<AttendanceResponse> {
+        println(authentication.name)
+
+        val attendances = getMemberAttendances.execute(
+            GetMemberAttendances.GetMemberAttendancesInput(
+                memberId = authentication.name,
+                generation = generation,
+            )
+        )
+        return attendances.map { AttendanceResponse.fromDomain(it) }
+    }
+}

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/AttendanceController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/AttendanceController.kt
@@ -4,7 +4,6 @@ import com.depromeet.makers.domain.usecase.GetMemberAttendances
 import com.depromeet.makers.presentation.restapi.dto.response.AttendanceResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -19,15 +18,12 @@ class AttendanceController(
     private val getMemberAttendances: GetMemberAttendances,
 ) {
 
-    @PreAuthorize("hasAnyRole('MEMBER', 'ORGANIZER')")
     @Operation(summary = "나의 출석 현황 조회", description = "로그인한 사용자의 출석 현황을 조회합니다.")
     @GetMapping("/me")
     fun getMyAttendance(
         authentication: Authentication,
         @RequestParam(defaultValue = "15") generation: Int,
     ): List<AttendanceResponse> {
-        println(authentication.name)
-
         val attendances = getMemberAttendances.execute(
             GetMemberAttendances.GetMemberAttendancesInput(
                 memberId = authentication.name,

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
@@ -21,7 +21,7 @@ class CheckInController(
     private val checkInSession: CheckInSession,
 ) {
 
-    @PreAuthorize("hasRole('MEMBER')")
+    @PreAuthorize("hasAnyRole('MEMBER', 'ORGANIZER')")
     @Operation(summary = "세션 출석", description = "세션에 출석합니다. (서버에서 현재 시간을 기준으로 출석 처리)")
     @PostMapping
     @ApiResponses(

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
@@ -1,6 +1,5 @@
 package com.depromeet.makers.presentation.restapi.controller
 
-import com.depromeet.makers.domain.model.Member
 import com.depromeet.makers.domain.usecase.CheckInSession
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -32,7 +31,7 @@ class CheckInController(
         ApiResponse(responseCode = "AT0004", description = "현재 주차에 해당하는 세션을 찾을 수 없습니다."),
         ApiResponse(responseCode = "AT0005", description = "현재 위치 파라미터가 누락되었습니다."),
         ApiResponse(responseCode = "AT0006", description = "현재 위치와 세션 장소의 거리가 너무 멉니다."),
-        )
+    )
     fun checkInSession(
         authentication: Authentication,
         @RequestParam("latitude", required = false) latitude: Double?,
@@ -41,7 +40,7 @@ class CheckInController(
         checkInSession.execute(
             CheckInSession.CheckInSessionInput(
                 now = LocalDateTime.now(),
-                member = authentication.principal as Member,
+                memberId = authentication.name,
                 latitude = latitude,
                 longitude = longitude,
             )

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -20,7 +19,6 @@ class CheckInController(
     private val checkInSession: CheckInSession,
 ) {
 
-    @PreAuthorize("hasAnyRole('MEMBER', 'ORGANIZER')")
     @Operation(summary = "세션 출석", description = "세션에 출석합니다. (서버에서 현재 시간을 기준으로 출석 처리)")
     @PostMapping
     @ApiResponses(

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/MeController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/MeController.kt
@@ -4,6 +4,7 @@ import com.depromeet.makers.domain.usecase.GetMemberById
 import com.depromeet.makers.presentation.restapi.dto.response.MemberResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 class MeController(
     private val getMemberById: GetMemberById,
 ) {
+    @PreAuthorize("hasAnyRole('MEMBER', 'ORGANIZER')")
     @Operation(summary = "로그인한 사용자 조회", description = "로그인한 사용자 정보를 조회합니다.")
     @GetMapping
     fun getMe(

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/MeController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/MeController.kt
@@ -4,7 +4,6 @@ import com.depromeet.makers.domain.usecase.GetMemberById
 import com.depromeet.makers.presentation.restapi.dto.response.MemberResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController
 class MeController(
     private val getMemberById: GetMemberById,
 ) {
-    @PreAuthorize("hasAnyRole('MEMBER', 'ORGANIZER')")
     @Operation(summary = "로그인한 사용자 조회", description = "로그인한 사용자 정보를 조회합니다.")
     @GetMapping
     fun getMe(

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/ViewSessionsController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/ViewSessionsController.kt
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -20,7 +19,6 @@ class ViewSessionsController(
 ) {
     @Operation(summary = "기수에 따른 모든 주차의 세션들 조회 요청", description = "기수에 따른 모든 주차의 세션들을 조회합니다.")
     @Parameter(name = "generation", description = "조회할 세션의 기수", example = "15")
-    @PreAuthorize("hasAnyRole('MEMBER', 'ORGANIZER')")
     @GetMapping
     fun viewSessions(
         @Valid request: ViewSessionsRequest,

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/ViewSessionsController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/ViewSessionsController.kt
@@ -20,7 +20,7 @@ class ViewSessionsController(
 ) {
     @Operation(summary = "기수에 따른 모든 주차의 세션들 조회 요청", description = "기수에 따른 모든 주차의 세션들을 조회합니다.")
     @Parameter(name = "generation", description = "조회할 세션의 기수", example = "15")
-    @PreAuthorize("hasRole('MEMBER')")
+    @PreAuthorize("hasAnyRole('MEMBER', 'ORGANIZER')")
     @GetMapping
     fun viewSessions(
         @Valid request: ViewSessionsRequest,

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/AttendanceResponse.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/AttendanceResponse.kt
@@ -1,0 +1,35 @@
+package com.depromeet.makers.presentation.restapi.dto.response
+
+import com.depromeet.makers.domain.model.AttendanceStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "출석 현황 DTO")
+data class AttendanceResponse(
+    @Schema(description = "기수", example = "15")
+    val generation: Int,
+
+    @Schema(description = "주차", example = "1")
+    val week: Int,
+
+    @Schema(description = "회원 ID", example = "01HWPNRE5TS9S7VC99WPETE5KE")
+    val memberId: String,
+
+    @Schema(description = "출석 상태", example = "ATTENDANCE")
+    val attendanceStatus: AttendanceStatus,
+
+    @Schema(description = "출석 시각", example = "2021-10-10T10:10:10")
+    val attendanceTime: LocalDateTime?,
+) {
+    companion object {
+        fun fromDomain(attendance: com.depromeet.makers.domain.model.Attendance) = with(attendance) {
+            AttendanceResponse(
+                generation = generation,
+                week = week,
+                memberId = member.memberId,
+                attendanceStatus = attendanceStatus,
+                attendanceTime = attendanceTime,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionTest.kt
@@ -4,6 +4,7 @@ import com.depromeet.makers.domain.exception.InvalidCheckInDistanceException
 import com.depromeet.makers.domain.exception.InvalidCheckInTimeException
 import com.depromeet.makers.domain.exception.MissingPlaceParamException
 import com.depromeet.makers.domain.gateway.AttendanceGateway
+import com.depromeet.makers.domain.gateway.MemberGateway
 import com.depromeet.makers.domain.gateway.SessionGateway
 import com.depromeet.makers.domain.model.Member
 import com.depromeet.makers.domain.model.Place
@@ -20,16 +21,11 @@ class CheckInSessionTest : BehaviorSpec({
     Given("온라인 세션에 출석할 때") {
         val attendanceGateway = mockk<AttendanceGateway>()
         val sessionGateway = mockk<SessionGateway>()
-        val checkInSession = CheckInSession(attendanceGateway, sessionGateway)
+        val memberGateway = mockk<MemberGateway>()
+        val checkInSession = CheckInSession(attendanceGateway, sessionGateway, memberGateway)
 
         val mockNow = LocalDateTime.of(2024, 5, 15, 16, 0)
-        val mockMember = Member(
-            memberId = "123e4567-e89b-12d3-a456-426614174000",
-            name = "홍길동",
-            email = "",
-            passCord = null,
-            generations = emptySet()
-        )
+        val mockMemberId = "123e4567-e89b-12d3-a456-426614174000"
         val mockLongitude = null
         val mockLatitude = null
 
@@ -44,6 +40,14 @@ class CheckInSessionTest : BehaviorSpec({
             place = Place.emptyPlace(),
         )
 
+        every { memberGateway.getById(any()) } returns Member(
+            memberId = "123e4567-e89b-12d3-a456-426614174000",
+            name = "홍길동",
+            email = "",
+            passCord = null,
+            generations = emptySet()
+        )
+
         every { attendanceGateway.findByMemberIdAndGenerationAndWeek(any(), any(), any()) } throws RuntimeException()
         every { attendanceGateway.save(any()) } returns mockk()
 
@@ -52,7 +56,7 @@ class CheckInSessionTest : BehaviorSpec({
                 checkInSession.execute(
                     CheckInSession.CheckInSessionInput(
                         now = mockNow,
-                        member = mockMember,
+                        memberId = mockMemberId,
                         longitude = mockLongitude,
                         latitude = mockLatitude,
                     )
@@ -68,21 +72,23 @@ class CheckInSessionTest : BehaviorSpec({
     Given("출석 세션이 존재하지 않는 온라인 세션에 출석할 때") {
         val attendanceGateway = mockk<AttendanceGateway>()
         val sessionGateway = mockk<SessionGateway>()
-        val checkInSession = CheckInSession(attendanceGateway, sessionGateway)
+        val memberGateway = mockk<MemberGateway>()
+        val checkInSession = CheckInSession(attendanceGateway, sessionGateway, memberGateway)
 
         val mockNow = LocalDateTime.of(2024, 6, 15, 16, 0)
-        val mockMember = Member(
+        val mockMemberId = "123e4567-e89b-12d3-a456-426614174000"
+        val mockLongitude = null
+        val mockLatitude = null
+
+        every { memberGateway.getById(any()) } returns Member(
             memberId = "123e4567-e89b-12d3-a456-426614174000",
             name = "홍길동",
             email = "",
             passCord = null,
             generations = emptySet()
         )
-        val mockLongitude = null
-        val mockLatitude = null
 
         every { sessionGateway.findByStartTimeBetween(any(), any()) } returns null
-
         every { attendanceGateway.findByMemberIdAndGenerationAndWeek(any(), any(), any()) } throws RuntimeException()
         every { attendanceGateway.save(any()) } returns mockk()
 
@@ -91,7 +97,7 @@ class CheckInSessionTest : BehaviorSpec({
                 checkInSession.execute(
                     CheckInSession.CheckInSessionInput(
                         now = mockNow,
-                        member = mockMember,
+                        memberId = mockMemberId,
                         longitude = mockLongitude,
                         latitude = mockLatitude,
                     )
@@ -107,16 +113,11 @@ class CheckInSessionTest : BehaviorSpec({
     Given("오프라인 세션에 출석할 때") {
         val attendanceGateway = mockk<AttendanceGateway>()
         val sessionGateway = mockk<SessionGateway>()
-        val checkInSession = CheckInSession(attendanceGateway, sessionGateway)
+        val memberGateway = mockk<MemberGateway>()
+        val checkInSession = CheckInSession(attendanceGateway, sessionGateway, memberGateway)
 
         val mockNow = LocalDateTime.of(2024, 5, 15, 16, 0)
-        val mockMember = Member(
-            memberId = "123e4567-e89b-12d3-a456-426614174000",
-            name = "홍길동",
-            email = "",
-            passCord = null,
-            generations = emptySet()
-        )
+        val mockMemberId = "123e4567-e89b-12d3-a456-426614174000"
         val mockLongitude = 127.0092
         val mockLatitude = 35.9418
 
@@ -135,6 +136,14 @@ class CheckInSessionTest : BehaviorSpec({
             ),
         )
 
+        every { memberGateway.getById(any()) } returns Member(
+            memberId = "123e4567-e89b-12d3-a456-426614174000",
+            name = "홍길동",
+            email = "",
+            passCord = null,
+            generations = emptySet()
+        )
+
         every { attendanceGateway.findByMemberIdAndGenerationAndWeek(any(), any(), any()) } throws RuntimeException()
         every { attendanceGateway.save(any()) } returns mockk()
 
@@ -143,7 +152,7 @@ class CheckInSessionTest : BehaviorSpec({
                 checkInSession.execute(
                     CheckInSession.CheckInSessionInput(
                         now = mockNow,
-                        member = mockMember,
+                        memberId = mockMemberId,
                         longitude = mockLongitude,
                         latitude = mockLatitude,
                     )
@@ -159,16 +168,11 @@ class CheckInSessionTest : BehaviorSpec({
     Given("위치에 벗어난 상태에서 오프라인 세션에 출석할 때") {
         val attendanceGateway = mockk<AttendanceGateway>()
         val sessionGateway = mockk<SessionGateway>()
-        val checkInSession = CheckInSession(attendanceGateway, sessionGateway)
+        val memberGateway = mockk<MemberGateway>()
+        val checkInSession = CheckInSession(attendanceGateway, sessionGateway, memberGateway)
 
         val mockNow = LocalDateTime.of(2024, 5, 15, 16, 0)
-        val mockMember = Member(
-            memberId = "123e4567-e89b-12d3-a456-426614174000",
-            name = "홍길동",
-            email = "",
-            passCord = null,
-            generations = emptySet()
-        )
+        val mockMemberId = "123e4567-e89b-12d3-a456-426614174000"
         val mockLongitude = 0.0
         val mockLatitude = 0.0
 
@@ -187,6 +191,14 @@ class CheckInSessionTest : BehaviorSpec({
             ),
         )
 
+        every { memberGateway.getById(any()) } returns Member(
+            memberId = "123e4567-e89b-12d3-a456-426614174000",
+            name = "홍길동",
+            email = "",
+            passCord = null,
+            generations = emptySet()
+        )
+
         every { attendanceGateway.findByMemberIdAndGenerationAndWeek(any(), any(), any()) } throws RuntimeException()
         every { attendanceGateway.save(any()) } returns mockk()
 
@@ -195,7 +207,7 @@ class CheckInSessionTest : BehaviorSpec({
                 checkInSession.execute(
                     CheckInSession.CheckInSessionInput(
                         now = mockNow,
-                        member = mockMember,
+                        memberId = mockMemberId,
                         longitude = mockLongitude,
                         latitude = mockLatitude,
                     )
@@ -211,16 +223,11 @@ class CheckInSessionTest : BehaviorSpec({
     Given("위치에 파라미터가 누락되어 오프라인 세션에 출석할 때") {
         val attendanceGateway = mockk<AttendanceGateway>()
         val sessionGateway = mockk<SessionGateway>()
-        val checkInSession = CheckInSession(attendanceGateway, sessionGateway)
+        val memberGateway = mockk<MemberGateway>()
+        val checkInSession = CheckInSession(attendanceGateway, sessionGateway, memberGateway)
 
         val mockNow = LocalDateTime.of(2024, 5, 15, 16, 0)
-        val mockMember = Member(
-            memberId = "123e4567-e89b-12d3-a456-426614174000",
-            name = "홍길동",
-            email = "",
-            passCord = null,
-            generations = emptySet()
-        )
+        val mockMemberId = "123e4567-e89b-12d3-a456-426614174000"
         val mockLongitude = null
         val mockLatitude = null
 
@@ -239,6 +246,14 @@ class CheckInSessionTest : BehaviorSpec({
             ),
         )
 
+        every { memberGateway.getById(any()) } returns Member(
+            memberId = "123e4567-e89b-12d3-a456-426614174000",
+            name = "홍길동",
+            email = "",
+            passCord = null,
+            generations = emptySet()
+        )
+
         every { attendanceGateway.findByMemberIdAndGenerationAndWeek(any(), any(), any()) } throws RuntimeException()
         every { attendanceGateway.save(any()) } returns mockk()
 
@@ -247,7 +262,7 @@ class CheckInSessionTest : BehaviorSpec({
                 checkInSession.execute(
                     CheckInSession.CheckInSessionInput(
                         now = mockNow,
-                        member = mockMember,
+                        memberId = mockMemberId,
                         longitude = mockLongitude,
                         latitude = mockLatitude,
                     )


### PR DESCRIPTION
# 💡 기능 
- 현재 로그인한 사용자의 출석정보 조회
  - 1~16주차를 기준으로 조회하도록 구현했습니다.
- 멤버 ROLE `MEMBER`만 해당하는 api `ORGANIZER`도 가능하도록 추가했습니다.

# 🔎 기타
- `member = authentication.principal as Member` 이거 안먹더라구요.. 변경했습니당
- 시큐리티에 도메인 빠져있는 부분 추가해넣었습니당
- 로컬에 띄워서 API 동작하는지 한번씩 테스트했슴당... (그래서 테스트 코드는 추후 작성 할래요...😂)

Close #16

