### PR TITLE
feat: 현재 출석 상태 조회 기능 구현

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/CheckInSession.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/CheckInSession.kt
@@ -67,11 +67,7 @@ class CheckInSession(
         attendanceGateway.save(attendance.checkIn(input.now, thisWeekSession.startTime))
     }
 
-    private fun LocalDateTime.getMonday(): LocalDateTime {
-        val dayOfWeek = this.dayOfWeek
-        val daysToAdd = DayOfWeek.MONDAY.value - dayOfWeek.value
-        return this.plusDays(daysToAdd.toLong())
-    }
+    private fun LocalDateTime.getMonday() = this.toLocalDate().with(DayOfWeek.MONDAY).atStartOfDay()
 
     private fun inRange(distance: Double, range: Double) = distance <= range
 

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/GetCheckInStatus.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/GetCheckInStatus.kt
@@ -77,10 +77,5 @@ class GetCheckInStatus(
         )
     }
 
-    private fun LocalDateTime.getMonday(): LocalDateTime {
-        val dayOfWeek = this.dayOfWeek
-        val daysToAdd = DayOfWeek.MONDAY.value - dayOfWeek.value
-        return this.plusDays(daysToAdd.toLong())
-    }
+    private fun LocalDateTime.getMonday() = this.toLocalDate().with(DayOfWeek.MONDAY).atStartOfDay()
 }
-

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/GetCheckInStatus.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/GetCheckInStatus.kt
@@ -1,0 +1,86 @@
+package com.depromeet.makers.domain.usecase
+
+import com.depromeet.makers.domain.exception.InvalidCheckInTimeException
+import com.depromeet.makers.domain.gateway.AttendanceGateway
+import com.depromeet.makers.domain.gateway.MemberGateway
+import com.depromeet.makers.domain.gateway.SessionGateway
+import com.depromeet.makers.domain.model.Attendance
+import com.depromeet.makers.domain.model.AttendanceStatus
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+
+class GetCheckInStatus(
+    private val memberGateway: MemberGateway,
+    private val sessionGateway: SessionGateway,
+    private val attendanceGateway: AttendanceGateway,
+) : UseCase<GetCheckInStatus.GetCheckInStatusInput, GetCheckInStatus.GetCheckInStatusOutput> {
+    data class GetCheckInStatusInput(
+        val now: LocalDateTime,
+        val memberId: String,
+    )
+
+    data class GetCheckInStatusOutput(
+        val generation: Int,
+        val week: Int,
+        val isBeforeSession15minutes: Boolean,
+        val needFloatingButton: Boolean,
+        val expectAttendanceStatus: AttendanceStatus,
+    )
+
+    override fun execute(input: GetCheckInStatusInput): GetCheckInStatusOutput {
+        val member = memberGateway.getById(input.memberId)
+
+        val monday = input.now.getMonday()
+        val thisWeekSession = sessionGateway.findByStartTimeBetween(
+            monday,
+            monday.plusDays(7)
+        ) ?: throw InvalidCheckInTimeException()
+
+        val attendance = runCatching {
+            attendanceGateway.findByMemberIdAndGenerationAndWeek(
+                member.memberId,
+                thisWeekSession.generation,
+                thisWeekSession.week
+            )
+        }.getOrDefault(
+            Attendance.newAttendance(
+                generation = thisWeekSession.generation,
+                week = thisWeekSession.week,
+                member = member,
+            )
+        )
+
+        // 현재 시간이 세션 시간 15분 전 && 세션 시작 시간 사이인지 확인 -> 팝업 띄우기 여부
+        val isBeforeSession15minutes = input.now.isAfter(thisWeekSession.startTime.minusMinutes(15)) &&
+                input.now.isBefore(thisWeekSession.startTime)
+
+        // 현재 시간이 출석 요청 가능 시간 사이 && 출석 상태가 ON_HOLD인 경우 -> 플로팅 버튼 띄우기 여부
+        val needFloatingButton = attendance.isAttendanceOnHold() &&
+                input.now.isAfter(thisWeekSession.startTime) && input.now.isBefore(thisWeekSession.startTime.plusMinutes(120))
+
+        val expectAttendanceStatus = when {
+            // 세션 시작 ~ 30분 사이 -> 출석으로 인정될 상태
+            input.now.isAfter(thisWeekSession.startTime) && input.now.isBefore(thisWeekSession.startTime.plusMinutes(30)) -> AttendanceStatus.ATTENDANCE
+            // 세션 시작 30분 ~ 120분 사이 -> 지각으로 인정될 상태
+            input.now.isAfter(thisWeekSession.startTime.plusMinutes(30)) &&
+                    input.now.isBefore(thisWeekSession.startTime.plusMinutes(120)) -> AttendanceStatus.TARDY
+
+            else -> AttendanceStatus.ATTENDANCE_ON_HOLD
+        }
+
+        return GetCheckInStatusOutput(
+            generation = attendance.generation,
+            week = attendance.week,
+            isBeforeSession15minutes = isBeforeSession15minutes,
+            needFloatingButton = needFloatingButton,
+            expectAttendanceStatus = expectAttendanceStatus,
+        )
+    }
+
+    private fun LocalDateTime.getMonday(): LocalDateTime {
+        val dayOfWeek = this.dayOfWeek
+        val daysToAdd = DayOfWeek.MONDAY.value - dayOfWeek.value
+        return this.plusDays(daysToAdd.toLong())
+    }
+}
+

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/db/repository/JpaSessionRepository.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/db/repository/JpaSessionRepository.kt
@@ -11,5 +11,5 @@ interface JpaSessionRepository : JpaRepository<SessionEntity, String> {
 
     fun findByGenerationAndWeek(generation: Int, week: Int): SessionEntity
 
-    fun findByStartTimeBetween(startTime: LocalDateTime, endTime: LocalDateTime): SessionEntity?
+    fun findByStartTimeBetween(startTime: LocalDateTime, endTime: LocalDateTime): List<SessionEntity>
 }

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/gateway/SessionGatewayImpl.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/gateway/SessionGatewayImpl.kt
@@ -50,6 +50,7 @@ class SessionGatewayImpl(
     ): Session? {
         return jpaSessionRepository
             .findByStartTimeBetween(startTime, endTime)
+            .firstOrNull()
             ?.toDomain()
     }
 }

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
@@ -1,11 +1,14 @@
 package com.depromeet.makers.presentation.restapi.controller
 
 import com.depromeet.makers.domain.usecase.CheckInSession
+import com.depromeet.makers.domain.usecase.GetCheckInStatus
+import com.depromeet.makers.presentation.restapi.dto.response.CheckInStatusResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -17,6 +20,7 @@ import java.time.LocalDateTime
 @RequestMapping("/v1/check-in")
 class CheckInController(
     private val checkInSession: CheckInSession,
+    private val getCheckInStatus: GetCheckInStatus,
 ) {
 
     @Operation(summary = "세션 출석", description = "세션에 출석합니다. (서버에서 현재 시간을 기준으로 출석 처리)")
@@ -42,6 +46,26 @@ class CheckInController(
                 latitude = latitude,
                 longitude = longitude,
             )
+        )
+    }
+
+    @Operation(summary = "세션 출석 상태", description = "현재 세션 출석 상태 확인합니다. (CheckInStatusResponse 스키마에 자세한 설명있습니다.)")
+    @GetMapping
+    fun checkInStatus(
+        authentication: Authentication,
+    ): CheckInStatusResponse {
+        val checkInStatus = getCheckInStatus.execute(
+            GetCheckInStatus.GetCheckInStatusInput(
+                now = LocalDateTime.now(),
+                memberId = authentication.name,
+            )
+        )
+        return CheckInStatusResponse(
+            generation = checkInStatus.generation,
+            week = checkInStatus.week,
+            isBeforeSession15minutes = checkInStatus.isBeforeSession15minutes,
+            needFloatingButton = checkInStatus.needFloatingButton,
+            expectAttendanceStatus = checkInStatus.expectAttendanceStatus,
         )
     }
 }

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/CheckInStatusResponse.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/CheckInStatusResponse.kt
@@ -1,0 +1,23 @@
+package com.depromeet.makers.presentation.restapi.dto.response
+
+import com.depromeet.makers.domain.model.AttendanceStatus
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "CheckInStatusResponse", description = "세션 출석 상태 응답 DTO")
+data class CheckInStatusResponse(
+    @Schema(name = "generation", description = "기수")
+    val generation: Int,
+
+    @Schema(name = "week", description = "주차")
+    val week: Int,
+
+    @Schema(name = "isBeforeSession15minutes", description = "팝업 메시지를 띄울지 여부 (세션 시작 15분 전 ~ 세션 시작 시간 사이인 경우)")
+    val isBeforeSession15minutes: Boolean,
+
+    @Schema(name = "needFloatingButton", description = "플로팅 버튼 노출 여부 (현재 시간이 출석 요청 가능 시간 && 멤버의 출석 상태가 ATTENDANCE_ON_HOLD 인 경우)")
+    val needFloatingButton: Boolean,
+
+    @Schema(name = "expectAttendanceStatus", description = "출석 시 예상하는 상태")
+    val expectAttendanceStatus: AttendanceStatus,
+) {
+}


### PR DESCRIPTION
# 💡 기능 
- 현재 출석 상태 조회에 대한 기능 구현
  - 아래 이미지에 해당하는 플로팅, 팝업창을 띄우기 위한 상태값 반환입니다.
  - 프론트단에서 1분단위 폴링 예정입니다.
``` kotlin
    @Schema(name = "generation", description = "기수")
    val generation: Int,

    @Schema(name = "week", description = "주차")
    val week: Int,

    @Schema(name = "isBeforeSession15minutes", description = "팝업 메시지를 띄울지 여부 (세션 시작 15분 전 ~ 세션 시작 시간 사이인 경우)")
    val isBeforeSession15minutes: Boolean,

    @Schema(name = "needFloatingButton", description = "플로팅 버튼 노출 여부 (현재 시간이 출석 요청 가능 시간 && 멤버의 출석 상태가 ATTENDANCE_ON_HOLD 인 경우)")
    val needFloatingButton: Boolean,

    @Schema(name = "expectAttendanceStatus", description = "출석 시 예상하는 상태")
    val expectAttendanceStatus: AttendanceStatus,
```
<img width="688" alt="image" src="https://github.com/depromeet/depromeet-makers-be/assets/91249216/48181474-2654-436b-ba0a-987e239d36da">
<img width="329" alt="image" src="https://github.com/depromeet/depromeet-makers-be/assets/91249216/e3a8d054-b573-41ae-bd49-37cc358c9060">

# 🔎 기타
- 한 주차에 여러 세션이 존재할 경우 방어로직 추가했습니다.

Close #28 

