### PR TITLE
feat: 내 출석 조회에 결석 현황 응답값 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/domain/gateway/SessionGateway.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/gateway/SessionGateway.kt
@@ -14,7 +14,7 @@ interface SessionGateway {
 
     fun findAllByGeneration(generation: Int): List<Session>
 
-    fun findByGenerationAndWeek(generation: Int, week: Int): Session
+    fun findByGenerationAndWeek(generation: Int, week: Int): Session?
 
     fun findByStartTimeBetween(startTime: LocalDateTime, endTime: LocalDateTime): Session?
 }

--- a/src/main/kotlin/com/depromeet/makers/domain/model/Attendance.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/model/Attendance.kt
@@ -11,6 +11,7 @@ data class Attendance(
     val generation: Int,
     val week: Int,
     val member: Member,
+    val sessionType: SessionType,
     val attendanceStatus: AttendanceStatus,
     val attendanceTime: LocalDateTime?
 ) {
@@ -80,12 +81,14 @@ data class Attendance(
             generation: Int,
             week: Int,
             member: Member,
+            sessionType: SessionType = SessionType.ONLINE,
             attendance: AttendanceStatus = AttendanceStatus.ATTENDANCE_ON_HOLD
         ) = Attendance(
             attendanceId = generateULID(),
             generation = generation,
             week = week,
             member = member,
+            sessionType = sessionType,
             attendanceStatus = attendance,
             attendanceTime = null
         )

--- a/src/main/kotlin/com/depromeet/makers/domain/model/AttendanceStatus.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/model/AttendanceStatus.kt
@@ -1,12 +1,13 @@
 package com.depromeet.makers.domain.model
 
 enum class AttendanceStatus(
-    val description: String
+    val description: String,
+    val point: Double,
 ) {
-    ATTENDANCE_ON_HOLD("출석 대기"),
-    ATTENDANCE("출석"),
-    ABSENCE("결석"),
-    TARDY("지각");
+    ATTENDANCE_ON_HOLD("출석 대기", 0.0),
+    ATTENDANCE("출석", 0.0),
+    ABSENCE("결석", 1.0),
+    TARDY("지각", 0.5);
 
     fun isAttendanceOnHold() = this == ATTENDANCE_ON_HOLD
 

--- a/src/main/kotlin/com/depromeet/makers/domain/model/Session.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/model/Session.kt
@@ -1,5 +1,6 @@
 package com.depromeet.makers.domain.model
 
+import com.depromeet.makers.util.generateULID
 import java.time.LocalDateTime
 
 data class Session(
@@ -34,5 +35,28 @@ data class Session(
             sessionType = sessionType,
             place = place,
         )
+    }
+
+    companion object {
+        fun newSession(
+            generation: Int,
+            week: Int,
+            title: String = "세션 제목입니다.",
+            description: String? = "",
+            startTime: LocalDateTime = LocalDateTime.now(),
+            sessionType: SessionType = SessionType.ONLINE,
+            place: Place = Place.emptyPlace(),
+        ): Session {
+            return Session(
+                sessionId = generateULID(),
+                generation = generation,
+                week = week,
+                title = title,
+                description = description,
+                startTime = startTime,
+                sessionType = sessionType,
+                place = place,
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/GetMemberAttendances.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/GetMemberAttendances.kt
@@ -2,18 +2,27 @@ package com.depromeet.makers.domain.usecase
 
 import com.depromeet.makers.domain.gateway.AttendanceGateway
 import com.depromeet.makers.domain.gateway.MemberGateway
+import com.depromeet.makers.domain.gateway.SessionGateway
 import com.depromeet.makers.domain.model.Attendance
 
 class GetMemberAttendances(
     private val attendanceGateway: AttendanceGateway,
     private val memberGateway: MemberGateway,
-) : UseCase<GetMemberAttendances.GetMemberAttendancesInput, List<Attendance>> {
+    private val sessionGateway: SessionGateway,
+) : UseCase<GetMemberAttendances.GetMemberAttendancesInput, GetMemberAttendances.GetMemberAttendancesOutput> {
     data class GetMemberAttendancesInput(
         val memberId: String,
         val generation: Int,
     )
 
-    override fun execute(input: GetMemberAttendancesInput): List<Attendance> {
+    data class GetMemberAttendancesOutput(
+        val generation: Int,
+        val offlineAbsenceScore: Double,
+        val totalAbsenceScore: Double,
+        val attendances: List<Attendance>,
+    )
+
+    override fun execute(input: GetMemberAttendancesInput): GetMemberAttendancesOutput {
         val member = memberGateway.getById(input.memberId)
 
         val attendances = attendanceGateway.findAllByMemberIdAndGeneration(member.memberId, input.generation)
@@ -22,13 +31,29 @@ class GetMemberAttendances(
 
         (1..16).filter { week -> !attendances.contains(week) }
             .forEach { week ->
-                attendances[week] = Attendance.newAttendance(
-                    member = member,
-                    generation = input.generation,
-                    week = week,
+                attendances[week] = attendanceGateway.save(
+                    Attendance.newAttendance(
+                        member = member,
+                        generation = input.generation,
+                        week = week,
+                    )
                 )
             }
 
-        return attendances.values.sortedBy { it.week }
+        var offlineAbsenceScore = 0.0
+        var totalAbsenceScore = 0.0
+        attendances.values.forEach {
+            offlineAbsenceScore += if (it.attendanceStatus.isAbsence() &&
+                runCatching { sessionGateway.findByGenerationAndWeek(input.generation, it.week).isOffline() }
+                    .getOrDefault(false)
+            ) 1.0 else 0.0
+            totalAbsenceScore += it.attendanceStatus.point
+        }
+        return GetMemberAttendancesOutput(
+            generation = input.generation,
+            offlineAbsenceScore = offlineAbsenceScore,
+            totalAbsenceScore = totalAbsenceScore,
+            attendances = attendances.values.sortedBy { it.week }
+        )
     }
 }

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/db/entity/AttendanceEntity.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/db/entity/AttendanceEntity.kt
@@ -2,6 +2,7 @@ package com.depromeet.makers.infrastructure.db.entity
 
 import com.depromeet.makers.domain.model.Attendance
 import com.depromeet.makers.domain.model.AttendanceStatus
+import com.depromeet.makers.domain.model.SessionType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -41,6 +42,7 @@ class AttendanceEntity private constructor(
         week = week,
         member = member.toDomain(),
         attendanceStatus = attendanceStatus,
+        sessionType = SessionType.ONLINE,
         attendanceTime = attendanceTime,
     )
 

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/db/entity/AttendanceEntity.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/db/entity/AttendanceEntity.kt
@@ -30,6 +30,10 @@ class AttendanceEntity private constructor(
     val member: MemberEntity,
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "session_type", nullable = false)
+    val sessionType: SessionType,
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "attendance_status", nullable = false)
     val attendanceStatus: AttendanceStatus,
 
@@ -42,7 +46,7 @@ class AttendanceEntity private constructor(
         week = week,
         member = member.toDomain(),
         attendanceStatus = attendanceStatus,
-        sessionType = SessionType.ONLINE,
+        sessionType = sessionType,
         attendanceTime = attendanceTime,
     )
 
@@ -53,6 +57,7 @@ class AttendanceEntity private constructor(
                 generation = generation,
                 week = week,
                 member = MemberEntity.fromDomain(member),
+                sessionType = sessionType,
                 attendanceStatus = attendanceStatus,
                 attendanceTime = attendanceTime
             )

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/db/repository/JpaSessionRepository.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/db/repository/JpaSessionRepository.kt
@@ -9,7 +9,7 @@ interface JpaSessionRepository : JpaRepository<SessionEntity, String> {
 
     fun findAllByGeneration(generation: Int): List<SessionEntity>
 
-    fun findByGenerationAndWeek(generation: Int, week: Int): SessionEntity
+    fun findByGenerationAndWeek(generation: Int, week: Int): SessionEntity?
 
     fun findByStartTimeBetween(startTime: LocalDateTime, endTime: LocalDateTime): List<SessionEntity>
 }

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/gateway/SessionGatewayImpl.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/gateway/SessionGatewayImpl.kt
@@ -38,10 +38,10 @@ class SessionGatewayImpl(
             .map { it.toDomain() }
     }
 
-    override fun findByGenerationAndWeek(generation: Int, week: Int): Session {
+    override fun findByGenerationAndWeek(generation: Int, week: Int): Session? {
         return jpaSessionRepository
             .findByGenerationAndWeek(generation, week)
-            .toDomain()
+            ?.toDomain()
     }
 
     override fun findByStartTimeBetween(

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/AttendanceController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/AttendanceController.kt
@@ -3,7 +3,7 @@ package com.depromeet.makers.presentation.restapi.controller
 import com.depromeet.makers.domain.usecase.GetMemberAttendances
 import com.depromeet.makers.domain.usecase.UpdateAttendance
 import com.depromeet.makers.presentation.restapi.dto.request.UpdateAttendanceRequest
-import com.depromeet.makers.presentation.restapi.dto.response.AttendanceResponse
+import com.depromeet.makers.presentation.restapi.dto.response.MyAttendanceResponse
 import com.depromeet.makers.presentation.restapi.dto.response.UpdateAttendanceResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -26,14 +26,15 @@ class AttendanceController(
     fun getMyAttendance(
         authentication: Authentication,
         @RequestParam(defaultValue = "15") generation: Int,
-    ): List<AttendanceResponse> {
-        val attendances = getMemberAttendances.execute(
-            GetMemberAttendances.GetMemberAttendancesInput(
-                memberId = authentication.name,
-                generation = generation,
+    ): MyAttendanceResponse {
+        return MyAttendanceResponse.fromDomain(
+            getMemberAttendances.execute(
+                GetMemberAttendances.GetMemberAttendancesInput(
+                    memberId = authentication.name,
+                    generation = generation,
+                )
             )
         )
-        return attendances.map { AttendanceResponse.fromDomain(it) }
     }
 
     @PreAuthorize("hasRole('ORGANIZER')")

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/AttendanceResponse.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/AttendanceResponse.kt
@@ -2,6 +2,7 @@ package com.depromeet.makers.presentation.restapi.dto.response
 
 import com.depromeet.makers.domain.model.Attendance
 import com.depromeet.makers.domain.model.AttendanceStatus
+import com.depromeet.makers.domain.model.SessionType
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
@@ -19,6 +20,9 @@ data class AttendanceResponse(
     @Schema(description = "회원 ID", example = "01HWPNRE5TS9S7VC99WPETE5KE")
     val memberId: String,
 
+    @Schema(description = "세션 타입", example = "ONLINE")
+    val sessionType: SessionType,
+
     @Schema(description = "출석 상태", example = "ATTENDANCE")
     val attendanceStatus: AttendanceStatus,
 
@@ -32,6 +36,7 @@ data class AttendanceResponse(
                 generation = generation,
                 week = week,
                 memberId = member.memberId,
+                sessionType = sessionType,
                 attendanceStatus = attendanceStatus,
                 attendanceTime = attendanceTime,
             )

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/MyAttendanceResponse.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/MyAttendanceResponse.kt
@@ -1,0 +1,27 @@
+package com.depromeet.makers.presentation.restapi.dto.response
+
+import com.depromeet.makers.domain.usecase.GetMemberAttendances
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class MyAttendanceResponse(
+
+    @Schema(description = "기수", example = "15")
+    val generation: Int,
+
+    @Schema(description = "오프라인 결석 점수", example = "1.0")
+    val offlineAbsenceScore: Double,
+
+    @Schema(description = "총 결석 점수 (지각: 0.5)", example = "2.5")
+    val totalAbsenceScore: Double,
+
+    val attendances: List<AttendanceResponse>
+) {
+    companion object {
+        fun fromDomain(getMemberAttendancesOutput: GetMemberAttendances.GetMemberAttendancesOutput) = MyAttendanceResponse(
+            generation = getMemberAttendancesOutput.generation,
+            offlineAbsenceScore = getMemberAttendancesOutput.offlineAbsenceScore,
+            totalAbsenceScore = getMemberAttendancesOutput.totalAbsenceScore,
+            attendances = getMemberAttendancesOutput.attendances.map { AttendanceResponse.fromDomain(it) }
+        )
+    }
+}


### PR DESCRIPTION
# 💡 기능 
- 내 출석 조회 부분에서 오프라인 결석 횟수, 결석 횟수에 대한 필드를 추가했습니다.
- 온오프라인 정보가 추가로 필요해서 추가했습니다.
- 16주치 세션, 출석 정보가 없다면 기본값을 세팅하도록 했습니다.
  - 요 부분은 나중에 걷어낼게요..!

# 🔎 기타


Close #32