### PR TITLE
feat: 세션 불참자 결석 처리 스케쥴러 구현

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/DepromeetMakersBeApplication.kt
+++ b/src/main/kotlin/com/depromeet/makers/DepromeetMakersBeApplication.kt
@@ -4,8 +4,12 @@ import com.depromeet.makers.domain.usecase.UseCase
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.EnableAspectJAutoProxy
 import org.springframework.context.annotation.FilterType
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableScheduling
+@EnableAspectJAutoProxy
 @SpringBootApplication
 @ComponentScan(
     includeFilters = [ComponentScan.Filter(

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/UpdateAbsenceMember.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/UpdateAbsenceMember.kt
@@ -1,0 +1,35 @@
+package com.depromeet.makers.domain.usecase
+
+import com.depromeet.makers.domain.gateway.AttendanceGateway
+import com.depromeet.makers.domain.gateway.SessionGateway
+import com.depromeet.makers.domain.model.AttendanceStatus
+import com.depromeet.makers.util.logger
+import java.time.LocalDateTime
+
+class UpdateAbsenceMember(
+    private val sessionGateway: SessionGateway,
+    private val attendanceGateway: AttendanceGateway,
+) : UseCase<UpdateAbsenceMember.UpdateAbsenceMemberInput, Unit> {
+    data class UpdateAbsenceMemberInput(
+        val today: LocalDateTime,
+    )
+
+    override fun execute(input: UpdateAbsenceMemberInput) {
+        val logger = logger()
+
+        val session = sessionGateway.findByStartTimeBetween(input.today, input.today.plusDays(1))
+        if (session == null) {
+            return
+        }
+
+        val attendances = attendanceGateway.findAllByGenerationAndWeek(session.generation, session.week)
+        attendances
+            .filter {
+                it.attendanceStatus == AttendanceStatus.ATTENDANCE_ON_HOLD
+            }
+            .forEach {
+                attendanceGateway.save(it.copy(attendanceStatus = AttendanceStatus.ABSENCE))
+                logger.info("memberId: ${it.member.memberId} has been changed to ${AttendanceStatus.ATTENDANCE}")
+            }
+    }
+}

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/config/aspect/SchedulerLogger.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/config/aspect/SchedulerLogger.kt
@@ -1,0 +1,26 @@
+package com.depromeet.makers.presentation.restapi.config.aspect
+
+import com.depromeet.makers.util.logger
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class SchedulerLogger {
+    val logger = logger()
+
+    @Around("@annotation(org.springframework.scheduling.annotation.Scheduled)")
+    fun logging(joinPoint: ProceedingJoinPoint): Any? {
+        val start = System.currentTimeMillis()
+        logger.info("Scheduler: ${joinPoint.target.javaClass.simpleName} start")
+
+        val result = joinPoint.proceed()
+
+        val end = System.currentTimeMillis()
+        logger.info("Scheduler: ${joinPoint.target.javaClass.simpleName} end, duration: ${end - start}ms")
+
+        return result
+    }
+}

--- a/src/main/kotlin/com/depromeet/makers/scheduler/AbsentMemberScheduler.kt
+++ b/src/main/kotlin/com/depromeet/makers/scheduler/AbsentMemberScheduler.kt
@@ -1,0 +1,20 @@
+package com.depromeet.makers.scheduler
+
+import com.depromeet.makers.domain.usecase.UpdateAbsenceMember
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@Component
+class AbsentMemberScheduler(
+    private val updateAbsenceMember: UpdateAbsenceMember
+) {
+
+    @Scheduled(cron = "0 0 20 ? * SAT")
+    fun scheduling() {
+        val today = LocalDateTime.of(LocalDate.now(), LocalTime.MIDNIGHT)
+        updateAbsenceMember.execute(UpdateAbsenceMember.UpdateAbsenceMemberInput(today))
+    }
+}

--- a/src/main/kotlin/com/depromeet/makers/scheduler/AbsentMemberScheduler.kt
+++ b/src/main/kotlin/com/depromeet/makers/scheduler/AbsentMemberScheduler.kt
@@ -13,7 +13,7 @@ class AbsentMemberScheduler(
 ) {
 
     @Scheduled(cron = "0 0 20 ? * SAT")
-    fun scheduling() {
+    fun updateAbsenceMember() {
         val today = LocalDateTime.of(LocalDate.now(), LocalTime.MIDNIGHT)
         updateAbsenceMember.execute(UpdateAbsenceMember.UpdateAbsenceMemberInput(today))
     }


### PR DESCRIPTION
# 💡 기능 
- 매주 토요일 20시 기점으로 해당 일자의 세션이 존재할 때, 출석 대기 상태의 멤버들의 출석 상태를 결석으로 변경합니다.

# 🔎 기타
- 추가적으로 로깅이 필요한 부분이 있을지 의견주세요!
- 스케쥴러 첨 구현해봤는데 문제 없는지도 한번 확인해주세용(테스트해 볼 방법이 없어성..) 🫡

Close #40 

