### PR TITLE
feat: 멤버 추가 시 출석 init 하도록 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/CreateNewMember.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/CreateNewMember.kt
@@ -51,8 +51,10 @@ class CreateNewMember(
                 initialGeneration = newGeneration,
             )
         }
-        initializeAttendance(newMember, newGeneration.generationId)
-        return memberGateway.save(newMember)
+
+        val member = memberGateway.save(newMember)
+        initializeAttendance(member, newGeneration.generationId)
+        return member
     }
 
     private fun initializeAttendance(member: Member, generationId: Int) {

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/GetCheckInStatus.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/GetCheckInStatus.kt
@@ -1,10 +1,10 @@
 package com.depromeet.makers.domain.usecase
 
 import com.depromeet.makers.domain.exception.InvalidCheckInTimeException
+import com.depromeet.makers.domain.exception.NotFoundAttendanceException
 import com.depromeet.makers.domain.gateway.AttendanceGateway
 import com.depromeet.makers.domain.gateway.MemberGateway
 import com.depromeet.makers.domain.gateway.SessionGateway
-import com.depromeet.makers.domain.model.Attendance
 import com.depromeet.makers.domain.model.AttendanceStatus
 import java.time.DayOfWeek
 import java.time.LocalDateTime
@@ -42,13 +42,7 @@ class GetCheckInStatus(
                 thisWeekSession.generation,
                 thisWeekSession.week
             )
-        }.getOrDefault(
-            Attendance.newAttendance(
-                generation = thisWeekSession.generation,
-                week = thisWeekSession.week,
-                member = member,
-            )
-        )
+        }.getOrElse { throw NotFoundAttendanceException() }
 
         // 현재 시간이 세션 시간 15분 전 && 세션 시작 시간 사이인지 확인 -> 팝업 띄우기 여부
         val isBeforeSession15minutes = input.now.isAfter(thisWeekSession.startTime.minusMinutes(15)) &&


### PR DESCRIPTION
# 💡 기능 
- 멤버 추가 시 출석 데이터들을 init 하도록 추가했습니다.
- 기존에 CheckIn 헬스 체크에 존재하던 default 출석 데이터 생성 로직을 제거했습니다.

# 🔎 기타
- 세션 생성이 우선시 되어야 합니다.
  - 생성된 세션을 기반으로 유저의 출석 정보를 생성합니다.
- **❗️기존 유저의 경우에도 잘 타는지 확인 부탁드려요!**

