### PR TITLE
feat: 결석 스케쥴러에 알림 발송 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/UpdateAbsenceMember.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/UpdateAbsenceMember.kt
@@ -1,14 +1,18 @@
 package com.depromeet.makers.domain.usecase
 
 import com.depromeet.makers.domain.gateway.AttendanceGateway
+import com.depromeet.makers.domain.gateway.NotificationGateway
 import com.depromeet.makers.domain.gateway.SessionGateway
 import com.depromeet.makers.domain.model.AttendanceStatus
+import com.depromeet.makers.domain.model.Notification
+import com.depromeet.makers.domain.model.NotificationType
 import com.depromeet.makers.util.logger
 import java.time.LocalDateTime
 
 class UpdateAbsenceMember(
     private val sessionGateway: SessionGateway,
     private val attendanceGateway: AttendanceGateway,
+    private val notificationGateway: NotificationGateway,
 ) : UseCase<UpdateAbsenceMember.UpdateAbsenceMemberInput, Unit> {
     data class UpdateAbsenceMemberInput(
         val today: LocalDateTime,
@@ -29,6 +33,15 @@ class UpdateAbsenceMember(
             }
             .forEach {
                 attendanceGateway.save(it.copy(attendanceStatus = AttendanceStatus.ABSENCE))
+                notificationGateway.save(
+                    Notification.newNotification(
+                        memberId = it.member.memberId,
+                        content = "출석 인증 시간이 초과되었습니다.\n" +
+                                "출석 증빙은 담당 운영진에게 문의하세요.",
+                        type = NotificationType.DOCUMENT,
+                        createdAt = input.today,
+                    )
+                )
                 logger.info("memberId: ${it.member.memberId} has been changed to ${AttendanceStatus.ATTENDANCE}")
             }
     }


### PR DESCRIPTION
# 💡 기능 
- 토요일마다 결석처리하는 스케쥴러에서 증빙 관련 알림을 전송하도록 추가했습니다.

# 🔎 기타


Close #93 