### PR TITLE
feat: 세션 조회 API 어드민의 경우에만 위도, 경도를 내리도록 수정

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/domain/model/Place.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/model/Place.kt
@@ -18,6 +18,13 @@ data class Place(
         name = name,
     )
 
+    fun maskLocation(): Place {
+        return copy(
+            longitude = 0.0,
+            latitude = 0.0,
+        )
+    }
+
     companion object {
         fun newPlace(
             address: String,

--- a/src/main/kotlin/com/depromeet/makers/domain/model/Session.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/model/Session.kt
@@ -17,6 +17,12 @@ data class Session(
 
     fun isOffline() = sessionType.isOffline()
 
+    fun maskLocation(): Session {
+        return copy(
+            place = place.maskLocation()
+        )
+    }
+
     fun update(
         generation: Int = this.generation,
         week: Int = this.week,

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/GetInfoSession.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/GetInfoSession.kt
@@ -11,15 +11,21 @@ class GetInfoSession(
 ) : UseCase<GetInfoSession.GetInfoSessionInput, Session> {
     data class GetInfoSessionInput(
         val now: LocalDateTime,
+        val isOrganizer: Boolean,
     )
 
     override fun execute(input: GetInfoSessionInput): Session {
         val monday = input.now.getMonday()
 
-        return sessionGateway.findByStartTimeBetween(
+        val session = sessionGateway.findByStartTimeBetween(
             monday,
             monday.plusDays(7)
         ) ?: throw SessionNotFoundException()
+
+        return when {
+            input.isOrganizer -> session
+            else -> session.maskLocation()
+        }
     }
 
     private fun LocalDateTime.getMonday() = this.toLocalDate().with(DayOfWeek.MONDAY).atStartOfDay()

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/GetSessions.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/GetSessions.kt
@@ -8,9 +8,15 @@ class GetSessions(
 ) : UseCase<GetSessions.GetSessionsInput, List<Session>> {
     data class GetSessionsInput(
         val generation: Int,
+        val isOrganizer: Boolean,
     )
 
     override fun execute(input: GetSessionsInput): List<Session> {
-        return sessionGateway.findAllByGeneration(input.generation).sortedBy { it.week }
+        val sessions = sessionGateway.findAllByGeneration(input.generation).sortedBy { it.week }
+
+        return when {
+            input.isOrganizer -> sessions
+            else -> sessions.map { it.maskLocation() }
+        }
     }
 }

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/SessionController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/SessionController.kt
@@ -1,5 +1,6 @@
 package com.depromeet.makers.presentation.restapi.controller
 
+import com.depromeet.makers.domain.model.MemberRole
 import com.depromeet.makers.domain.usecase.*
 import com.depromeet.makers.presentation.restapi.dto.request.CreateNewSessionRequest
 import com.depromeet.makers.presentation.restapi.dto.request.GetSessionsRequest
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDateTime
 
@@ -52,11 +54,13 @@ class SessionController(
     @Parameter(name = "generation", description = "조회할 세션의 기수", example = "15")
     @GetMapping
     fun getSessions(
+        authentication: Authentication,
         @Valid request: GetSessionsRequest,
     ): GetSessionsResponse {
         val sessions = getSessions.execute(
             GetSessions.GetSessionsInput(
                 generation = request.generation,
+                isOrganizer = authentication.authorities.any { it.authority == MemberRole.ORGANIZER.roleName }
             )
         ).map { GetSessionsResponse.SessionResponse.fromDomain(it) }
 
@@ -69,11 +73,13 @@ class SessionController(
     @Operation(summary = "세션 정보 조회", description = "세션의 정보를 조회합니다.")
     @GetMapping("/info")
     fun getInfoSession(
+        authentication: Authentication,
     ): GetSessionResponse {
         return GetSessionResponse.fromDomain(
             getInfoSession.execute(
                 GetInfoSession.GetInfoSessionInput(
                     now = LocalDateTime.now(),
+                    isOrganizer = authentication.authorities.any { it.authority == MemberRole.ORGANIZER.roleName }
                 )
             )
         )

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/SessionController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/SessionController.kt
@@ -50,7 +50,11 @@ class SessionController(
         return CreateNewSessionResponse.fromDomain(session)
     }
 
-    @Operation(summary = "기수에 따른 모든 주차의 세션들 조회 요청", description = "기수에 따른 모든 주차의 세션들을 조회합니다.")
+    @Operation(
+        summary = "기수에 따른 모든 주차의 세션들 조회 요청",
+        description = "기수에 따른 모든 주차의 세션들을 조회합니다.\n" +
+                "일반 유저의 경우 위도, 경도가 0.0 으로 마스킹되어 반환됩니다."
+    )
     @Parameter(name = "generation", description = "조회할 세션의 기수", example = "15")
     @GetMapping
     fun getSessions(
@@ -70,7 +74,10 @@ class SessionController(
         )
     }
 
-    @Operation(summary = "세션 정보 조회", description = "세션의 정보를 조회합니다.")
+    @Operation(
+        summary = "세션 정보 조회", description = "세션의 정보를 조회합니다.\n" +
+                "일반 유저의 경우 위도, 경도가 0.0 으로 마스킹되어 반환됩니다."
+    )
     @GetMapping("/info")
     fun getInfoSession(
         authentication: Authentication,

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionTest.kt
@@ -147,6 +147,7 @@ class CheckInSessionTest : BehaviorSpec({
             sessionType = SessionType.OFFLINE,
             place = Place(
                 address = "전북 익산시 부송동 100",
+                name = "오프라인 장소",
                 latitude = 35.9418,
                 longitude = 127.0092,
             ),
@@ -214,6 +215,7 @@ class CheckInSessionTest : BehaviorSpec({
             sessionType = SessionType.OFFLINE,
             place = Place(
                 address = "전북 익산시 부송동 100",
+                name = "오프라인 장소",
                 latitude = 35.9418,
                 longitude = 127.0092,
             ),
@@ -282,6 +284,7 @@ class CheckInSessionTest : BehaviorSpec({
             sessionType = SessionType.OFFLINE,
             place = Place(
                 address = "전북 익산시 부송동 100",
+                name = "오프라인 장소",
                 latitude = 35.9418,
                 longitude = 127.0092,
             ),

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/CreateNewSessionTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/CreateNewSessionTest.kt
@@ -42,6 +42,7 @@ class CreateNewSessionTest : BehaviorSpec({
                     address = mockAddress,
                     longitude = mockLongitude,
                     latitude = mockLatitude,
+                    placeName = "장소",
                 )
             )
             Then("세션 정보가 등록된다.") {
@@ -62,6 +63,7 @@ class CreateNewSessionTest : BehaviorSpec({
                     address = mockAddress,
                     longitude = mockLongitude,
                     latitude = mockLatitude,
+                    placeName = "장소",
                 )
             )
             Then("널 값의 description으로 세션 정보가 등록된다.") {
@@ -100,6 +102,7 @@ class CreateNewSessionTest : BehaviorSpec({
                     address = mockAddress,
                     longitude = mockLongitude,
                     latitude = mockLatitude,
+                    placeName = "장소",
                 )
             )
             Then("세션 정보가 등록된다.") {
@@ -144,6 +147,7 @@ class CreateNewSessionTest : BehaviorSpec({
                         address = mockAddress,
                         longitude = mockLongitude,
                         latitude = mockLatitude,
+                        placeName = "장소",
                     )
                 )
             }

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/GetInfoSessionTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/GetInfoSessionTest.kt
@@ -1,0 +1,85 @@
+package com.depromeet.makers.domain.usecase
+
+import com.depromeet.makers.domain.gateway.SessionGateway
+import com.depromeet.makers.domain.model.Place
+import com.depromeet.makers.domain.model.Session
+import com.depromeet.makers.domain.model.SessionType
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+
+class GetInfoSessionTest : BehaviorSpec({
+    Given("MEMBER ROLE을 가진 유저가 오늘의 세션을 조회할 때") {
+        val sessionGateway = mockk<SessionGateway>()
+        val getSessions = GetInfoSession(sessionGateway)
+
+        val mockSession = Session(
+            sessionId = "123e4567-e89b-12d3-a456-426614174000",
+            generation = 15,
+            week = 1,
+            title = "세션 제목",
+            description = "세션 설명",
+            startTime = LocalDateTime.of(2030, 10, 1, 10, 0),
+            sessionType = SessionType.OFFLINE,
+            place = Place.newPlace(
+                address = "서울특별시 강남구 테헤란로 521",
+                longitude = 127.034,
+                latitude = 37.501,
+                name = "장소"
+            ),
+        )
+        every { sessionGateway.findByStartTimeBetween(any(), any()) } returns mockSession
+
+        When("execute가 실행되면") {
+            val result = getSessions.execute(
+                GetInfoSession.GetInfoSessionInput(
+                    now = LocalDateTime.of(2030, 10, 1, 10, 0),
+                    isOrganizer = false
+                )
+            )
+
+            Then("위치 정보가 마스킹되어 반환된다") {
+                result.place.longitude shouldBe 0.0
+                result.place.latitude shouldBe 0.0
+            }
+        }
+    }
+
+    Given("ORGANIZER ROLE을 가진 유저가 오늘의 세션을 조회할 때") {
+        val sessionGateway = mockk<SessionGateway>()
+        val getSessions = GetInfoSession(sessionGateway)
+
+        val mockSession = Session(
+            sessionId = "123e4567-e89b-12d3-a456-426614174000",
+            generation = 15,
+            week = 1,
+            title = "세션 제목",
+            description = "세션 설명",
+            startTime = LocalDateTime.of(2030, 10, 1, 10, 0),
+            sessionType = SessionType.OFFLINE,
+            place = Place.newPlace(
+                address = "서울특별시 강남구 테헤란로 521",
+                longitude = 127.034,
+                latitude = 37.501,
+                name = "장소"
+            ),
+        )
+        every { sessionGateway.findByStartTimeBetween(any(), any()) } returns mockSession
+
+        When("execute가 실행되면") {
+            val result = getSessions.execute(
+                GetInfoSession.GetInfoSessionInput(
+                    now = LocalDateTime.of(2030, 10, 1, 10, 0),
+                    isOrganizer = true
+                )
+            )
+
+            Then("위치 정보가 마스킹되지 않고 반환된다") {
+                result.place.longitude shouldBe 127.034
+                result.place.latitude shouldBe 37.501
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/GetSessionsTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/GetSessionsTest.kt
@@ -34,6 +34,7 @@ class GetSessionsTest : BehaviorSpec({
             val result = getSessions.execute(
                 GetSessions.GetSessionsInput(
                     generation = 15,
+                    isOrganizer = false
                 )
             )
 
@@ -42,6 +43,82 @@ class GetSessionsTest : BehaviorSpec({
             }
             Then("주차별로 정렬되어 반환된다.") {
                 result shouldBe mockShuffledSessionList.sortedBy { it.week }
+            }
+        }
+    }
+
+    Given("MEMBER ROLE을 가진 유저가 모든 세션을 조회할 때") {
+        val sessionGateway = mockk<SessionGateway>()
+        val getSessions = GetSessions(sessionGateway)
+
+        val mockSessionList = listOf(
+            Session(
+                sessionId = "123e4567-e89b-12d3-a456-426614174000",
+                generation = 15,
+                week = 1,
+                title = "세션 제목",
+                description = "세션 설명",
+                startTime = LocalDateTime.of(2030, 10, 1, 10, 0),
+                sessionType = SessionType.OFFLINE,
+                place = Place.newPlace(
+                    address = "서울특별시 강남구 테헤란로 521",
+                    longitude = 127.034,
+                    latitude = 37.501,
+                    name = "장소"
+                ),
+            )
+        )
+        every { sessionGateway.findAllByGeneration(any()) } returns mockSessionList
+
+        When("execute가 실행되면") {
+            val result = getSessions.execute(
+                GetSessions.GetSessionsInput(
+                    generation = 15,
+                    isOrganizer = false
+                )
+            )
+
+            Then("위치 정보가 마스킹되어 반환된다") {
+                result[0].place.longitude shouldBe 0.0
+                result[0].place.latitude shouldBe 0.0
+            }
+        }
+    }
+
+    Given("ORGANIZER ROLE을 가진 유저가 모든 세션을 조회할 때") {
+        val sessionGateway = mockk<SessionGateway>()
+        val getSessions = GetSessions(sessionGateway)
+
+        val mockSessionList = listOf(
+            Session(
+                sessionId = "123e4567-e89b-12d3-a456-426614174000",
+                generation = 15,
+                week = 1,
+                title = "세션 제목",
+                description = "세션 설명",
+                startTime = LocalDateTime.of(2030, 10, 1, 10, 0),
+                sessionType = SessionType.OFFLINE,
+                place = Place.newPlace(
+                    address = "서울특별시 강남구 테헤란로 521",
+                    longitude = 127.034,
+                    latitude = 37.501,
+                    name = "장소"
+                ),
+            )
+        )
+        every { sessionGateway.findAllByGeneration(any()) } returns mockSessionList
+
+        When("execute가 실행되면") {
+            val result = getSessions.execute(
+                GetSessions.GetSessionsInput(
+                    generation = 15,
+                    isOrganizer = true
+                )
+            )
+
+            Then("위치 정보가 마스킹되어 반환된다") {
+                result[0].place.longitude shouldBe 127.034
+                result[0].place.latitude shouldBe 37.501
             }
         }
     }

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/UpdateSessionPlaceTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/UpdateSessionPlaceTest.kt
@@ -17,6 +17,7 @@ class UpdateSessionPlaceTest : BehaviorSpec({
 
         val mockPreviousSessionPlace = Place(
             address = "전북 익산시 부송동 100",
+            name = "오프라인 장소",
             latitude = 35.9418,
             longitude = 127.0092,
         )
@@ -41,6 +42,7 @@ class UpdateSessionPlaceTest : BehaviorSpec({
                 mockPreviousSession.copy(
                     place = Place(
                         address = mockAddress,
+                        name = "오프라인 장소",
                         latitude = mockLatitude,
                         longitude = mockLongitude,
                     )
@@ -54,6 +56,7 @@ class UpdateSessionPlaceTest : BehaviorSpec({
                     address = mockAddress,
                     latitude = mockLatitude,
                     longitude = mockLongitude,
+                    name = "오프라인 장소",
                 )
             )
 


### PR DESCRIPTION
# 💡 기능 
- 일반 유저 Role 에서 세션 조회 시 불필요한 위도 경도 정보를 내리지 않도록 수정했습니다.

# 🔎 기타

Close #115 