### PR TITLE
feat: 오프라인 출석 코드 기능 추가

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/domain/exception/AttendanceException.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/exception/AttendanceException.kt
@@ -11,3 +11,5 @@ class InvalidCheckInTimeException : AttendanceException(ErrorCode.INVALID_CHECKI
 class MissingPlaceParamException : AttendanceException(ErrorCode.MISSING_PLACE_PARAM)
 class InvalidCheckInDistanceException : AttendanceException(ErrorCode.INVALID_CHECKIN_DISTANCE)
 class NotFoundAttendanceException : AttendanceException(ErrorCode.NOT_EXIST_ATTENDANCE)
+class InvalidCheckInCodeException : AttendanceException(ErrorCode.INVALID_CHECKIN_CODE)
+class NotSupportedCheckInCodeException : AttendanceException(ErrorCode.NOT_SUPPORTED_CHECKIN_CODE)

--- a/src/main/kotlin/com/depromeet/makers/domain/exception/AttendanceException.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/exception/AttendanceException.kt
@@ -2,7 +2,8 @@ package com.depromeet.makers.domain.exception
 
 open class AttendanceException(
     errorCode: ErrorCode,
-) : DomainException(errorCode)
+    data: Any? = null,
+) : DomainException(errorCode, data)
 
 class AttendanceBeforeTimeException : AttendanceException(ErrorCode.BEFORE_AVAILABLE_ATTENDANCE_TIME)
 class AttendanceAfterTimeException : AttendanceException(ErrorCode.AFTER_AVAILABLE_ATTENDANCE_TIME)
@@ -11,5 +12,6 @@ class InvalidCheckInTimeException : AttendanceException(ErrorCode.INVALID_CHECKI
 class MissingPlaceParamException : AttendanceException(ErrorCode.MISSING_PLACE_PARAM)
 class InvalidCheckInDistanceException : AttendanceException(ErrorCode.INVALID_CHECKIN_DISTANCE)
 class NotFoundAttendanceException : AttendanceException(ErrorCode.NOT_EXIST_ATTENDANCE)
-class InvalidCheckInCodeException : AttendanceException(ErrorCode.INVALID_CHECKIN_CODE)
+class InvalidCheckInCodeException(data: Any?) : AttendanceException(ErrorCode.INVALID_CHECKIN_CODE, data)
 class NotSupportedCheckInCodeException : AttendanceException(ErrorCode.NOT_SUPPORTED_CHECKIN_CODE)
+class TryCountOverException : AttendanceException(ErrorCode.TRY_COUNT_OVER)

--- a/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
@@ -58,4 +58,5 @@ enum class ErrorCode(
     NOT_EXIST_ATTENDANCE("AT0007", "해당하는 출석 정보가 없습니다."),
     INVALID_CHECKIN_CODE("AT0008", "출석 코드가 일치하지 않습니다."),
     NOT_SUPPORTED_CHECKIN_CODE("AT0009", "출석 코드로 출석할 수 없는 세션입니다."),
+    TRY_COUNT_OVER("AT0010", "출석 시도 횟수를 초과하였습니다."),
 }

--- a/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
@@ -56,7 +56,7 @@ enum class ErrorCode(
     MISSING_PLACE_PARAM("AT0005", "오프라인 세션 출석체크의 현재 위치 정보가 누락되었습니다."),
     INVALID_CHECKIN_DISTANCE("AT0006", "현재 위치와 세션 장소의 거리가 너무 멉니다."),
     NOT_EXIST_ATTENDANCE("AT0007", "해당하는 출석 정보가 없습니다."),
-    INVALID_CHECKIN_CODE("AT0008", "출석 코드가 일치하지 않습니다."),
+    INVALID_CHECKIN_CODE("AT0008", "잘못된 출석 코드입니다. 다시 시도해주세요."),
     NOT_SUPPORTED_CHECKIN_CODE("AT0009", "출석 코드로 출석할 수 없는 세션입니다."),
-    TRY_COUNT_OVER("AT0010", "출석 시도 횟수를 초과하였습니다."),
+    TRY_COUNT_OVER("AT0010", "출석 인증 횟수를 초과했습니다."),
 }

--- a/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
@@ -55,5 +55,7 @@ enum class ErrorCode(
     INVALID_CHECKIN_TIME("AT0004", "현재 주차에 해당하는 세션을 찾을 수 없습니다."),
     MISSING_PLACE_PARAM("AT0005", "오프라인 세션 출석체크의 현재 위치 정보가 누락되었습니다."),
     INVALID_CHECKIN_DISTANCE("AT0006", "현재 위치와 세션 장소의 거리가 너무 멉니다."),
-    NOT_EXIST_ATTENDANCE("AT0007", "해당하는 출석 정보가 없습니다.")
+    NOT_EXIST_ATTENDANCE("AT0007", "해당하는 출석 정보가 없습니다."),
+    INVALID_CHECKIN_CODE("AT0008", "출석 코드가 일치하지 않습니다."),
+    NOT_SUPPORTED_CHECKIN_CODE("AT0009", "출석 코드로 출석할 수 없는 세션입니다."),
 }

--- a/src/main/kotlin/com/depromeet/makers/domain/model/Attendance.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/model/Attendance.kt
@@ -13,7 +13,8 @@ data class Attendance(
     val member: Member,
     val sessionType: SessionType,
     val attendanceStatus: AttendanceStatus,
-    val attendanceTime: LocalDateTime?
+    val attendanceTime: LocalDateTime?,
+    val tryCount: Int,
 ) {
     fun checkIn(now: LocalDateTime, attendanceStatus: AttendanceStatus): Attendance {
         return this.copy(
@@ -51,13 +52,20 @@ data class Attendance(
 
     fun isTardy() = attendanceStatus.isTardy()
 
+    fun tryCountUp() = this.copy(tryCount = tryCount + 1)
+
+    fun isTryCountOver() = tryCount >= MAX_TRY_COUNT
+
+    fun getTryCount() = TryCount(tryCount)
+
     fun update(
         attendanceId: String = this.attendanceId,
         generation: Int = this.generation,
         week: Int = this.week,
         member: Member = this.member,
         attendanceStatus: AttendanceStatus = this.attendanceStatus,
-        attendanceTime: LocalDateTime? = this.attendanceTime
+        attendanceTime: LocalDateTime? = this.attendanceTime,
+        tryCount: Int = this.tryCount,
     ): Attendance {
         return this.copy(
             attendanceId = attendanceId,
@@ -65,11 +73,14 @@ data class Attendance(
             week = week,
             member = member,
             attendanceStatus = attendanceStatus,
-            attendanceTime = attendanceTime
+            attendanceTime = attendanceTime,
+            tryCount = tryCount
         )
     }
 
     companion object {
+        const val MAX_TRY_COUNT = 3 // 최대 출석 코드 기입 횟수
+
         fun newAttendance(
             generation: Int,
             week: Int,
@@ -83,7 +94,12 @@ data class Attendance(
             member = member,
             sessionType = sessionType,
             attendanceStatus = attendance,
-            attendanceTime = null
+            attendanceTime = null,
+            tryCount = 0
         )
     }
+
+    data class TryCount(
+        val tryCount: Int,
+    )
 }

--- a/src/main/kotlin/com/depromeet/makers/domain/model/Session.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/model/Session.kt
@@ -2,6 +2,7 @@ package com.depromeet.makers.domain.model
 
 import com.depromeet.makers.util.generateULID
 import java.time.LocalDateTime
+import kotlin.random.Random
 
 data class Session(
     val sessionId: String,
@@ -12,14 +13,16 @@ data class Session(
     val startTime: LocalDateTime,
     val sessionType: SessionType,
     val place: Place,
+    val code: String? = generateCode(),
 ) {
     fun isOnline() = sessionType.isOnline()
 
     fun isOffline() = sessionType.isOffline()
 
-    fun maskLocation(): Session {
+    fun mask(): Session {
         return copy(
-            place = place.maskLocation()
+            place = place.maskLocation(),
+            code = null,
         )
     }
 
@@ -63,6 +66,11 @@ data class Session(
                 sessionType = sessionType,
                 place = place,
             )
+        }
+
+        fun generateCode(): String {
+            val randomNumber = Random.nextInt(0, 10000)
+            return String.format("%04d", randomNumber)
         }
     }
 }

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionWithCode.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionWithCode.kt
@@ -2,7 +2,7 @@ package com.depromeet.makers.domain.usecase
 
 import com.depromeet.makers.domain.exception.*
 import com.depromeet.makers.domain.gateway.AttendanceGateway
-import com.depromeet.makers.domain.gateway.NotificationGateway
+import com.depromeet.makers.domain.gateway.MemberGateway
 import com.depromeet.makers.domain.gateway.SessionGateway
 import com.depromeet.makers.domain.model.Attendance
 import java.time.DayOfWeek
@@ -11,7 +11,7 @@ import java.time.LocalDateTime
 class CheckInSessionWithCode(
     private val attendanceGateway: AttendanceGateway,
     private val sessionGateway: SessionGateway,
-    private val memGateway: NotificationGateway,
+    private val memberGateway: MemberGateway,
 ) : UseCase<CheckInSessionWithCode.CheckInSessionWithCodeInput, Attendance> {
     data class CheckInSessionWithCodeInput(
         val memberId: String,
@@ -20,7 +20,7 @@ class CheckInSessionWithCode(
     )
 
     override fun execute(input: CheckInSessionWithCodeInput): Attendance {
-        val member = memGateway.getById(input.memberId)
+        val member = memberGateway.getById(input.memberId)
         val monday = input.now.getMonday()
 
         val thisWeekSession =

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionWithCode.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionWithCode.kt
@@ -1,9 +1,6 @@
 package com.depromeet.makers.domain.usecase
 
-import com.depromeet.makers.domain.exception.InvalidCheckInCodeException
-import com.depromeet.makers.domain.exception.InvalidCheckInTimeException
-import com.depromeet.makers.domain.exception.NotFoundAttendanceException
-import com.depromeet.makers.domain.exception.NotSupportedCheckInCodeException
+import com.depromeet.makers.domain.exception.*
 import com.depromeet.makers.domain.gateway.AttendanceGateway
 import com.depromeet.makers.domain.gateway.NotificationGateway
 import com.depromeet.makers.domain.gateway.SessionGateway
@@ -45,10 +42,15 @@ class CheckInSessionWithCode(
                 )
             }.getOrElse { throw NotFoundAttendanceException() }
 
+        if (attendance.isTryCountOver()) {
+            throw TryCountOverException()
+        }
+
         attendance.isAvailableCheckInRequest(thisWeekSession.startTime, input.now)
 
         if (thisWeekSession.code != input.code) {
-            throw InvalidCheckInCodeException()
+            attendanceGateway.save(attendance.tryCountUp())
+            throw InvalidCheckInCodeException(attendance.getTryCount())
         }
 
         val expectAttendanceStatus = attendance.expectAttendanceStatus(thisWeekSession.startTime, input.now)

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionWithCode.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionWithCode.kt
@@ -1,0 +1,59 @@
+package com.depromeet.makers.domain.usecase
+
+import com.depromeet.makers.domain.exception.InvalidCheckInCodeException
+import com.depromeet.makers.domain.exception.InvalidCheckInTimeException
+import com.depromeet.makers.domain.exception.NotFoundAttendanceException
+import com.depromeet.makers.domain.exception.NotSupportedCheckInCodeException
+import com.depromeet.makers.domain.gateway.AttendanceGateway
+import com.depromeet.makers.domain.gateway.NotificationGateway
+import com.depromeet.makers.domain.gateway.SessionGateway
+import com.depromeet.makers.domain.model.Attendance
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+
+class CheckInSessionWithCode(
+    private val attendanceGateway: AttendanceGateway,
+    private val sessionGateway: SessionGateway,
+    private val memGateway: NotificationGateway,
+) : UseCase<CheckInSessionWithCode.CheckInSessionWithCodeInput, Attendance> {
+    data class CheckInSessionWithCodeInput(
+        val memberId: String,
+        val now: LocalDateTime,
+        val code: String,
+    )
+
+    override fun execute(input: CheckInSessionWithCodeInput): Attendance {
+        val member = memGateway.getById(input.memberId)
+        val monday = input.now.getMonday()
+
+        val thisWeekSession =
+            sessionGateway.findByStartTimeBetween(
+                monday,
+                monday.plusDays(7),
+            ) ?: throw InvalidCheckInTimeException()
+
+        if (thisWeekSession.isOnline()) {
+            throw NotSupportedCheckInCodeException()
+        }
+
+        val attendance =
+            runCatching {
+                attendanceGateway.findByMemberIdAndGenerationAndWeek(
+                    member.memberId,
+                    thisWeekSession.generation,
+                    thisWeekSession.week,
+                )
+            }.getOrElse { throw NotFoundAttendanceException() }
+
+        attendance.isAvailableCheckInRequest(thisWeekSession.startTime, input.now)
+
+        if (thisWeekSession.code != input.code) {
+            throw InvalidCheckInCodeException()
+        }
+
+        val expectAttendanceStatus = attendance.expectAttendanceStatus(thisWeekSession.startTime, input.now)
+        return attendanceGateway.save(attendance.checkIn(input.now, expectAttendanceStatus))
+    }
+
+    private fun LocalDateTime.getMonday() = this.toLocalDate().with(DayOfWeek.MONDAY).atStartOfDay()
+}

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/GetInfoSession.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/GetInfoSession.kt
@@ -24,7 +24,7 @@ class GetInfoSession(
 
         return when {
             input.isOrganizer -> session
-            else -> session.maskLocation()
+            else -> session.mask()
         }
     }
 

--- a/src/main/kotlin/com/depromeet/makers/domain/usecase/GetSessions.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/usecase/GetSessions.kt
@@ -16,7 +16,7 @@ class GetSessions(
 
         return when {
             input.isOrganizer -> sessions
-            else -> sessions.map { it.maskLocation() }
+            else -> sessions.map { it.mask() }
         }
     }
 }

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/db/entity/AttendanceEntity.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/db/entity/AttendanceEntity.kt
@@ -39,6 +39,9 @@ class AttendanceEntity private constructor(
 
     @Column(name = "attendance_time", nullable = true)
     val attendanceTime: LocalDateTime?,
+
+    @Column(name = "try_count", nullable = true)
+    var tryCount: Int? = 0,
 ) {
     fun toDomain() = Attendance(
         attendanceId = id,
@@ -48,6 +51,7 @@ class AttendanceEntity private constructor(
         attendanceStatus = attendanceStatus,
         sessionType = sessionType,
         attendanceTime = attendanceTime,
+        tryCount = tryCount ?: 0
     )
 
     companion object {
@@ -59,7 +63,8 @@ class AttendanceEntity private constructor(
                 member = MemberEntity.fromDomain(member),
                 sessionType = sessionType,
                 attendanceStatus = attendanceStatus,
-                attendanceTime = attendanceTime
+                attendanceTime = attendanceTime,
+                tryCount = tryCount,
             )
         }
     }

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/db/entity/SessionEntity.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/db/entity/SessionEntity.kt
@@ -43,6 +43,9 @@ class SessionEntity private constructor(
     @Column(name = "place_name", nullable = true, columnDefinition = "VARCHAR(255)")
     var placeName: String?,
 
+    @Column(name = "code")
+    var code: String?,
+
     ) {
     fun toDomain(): Session {
         return Session(
@@ -54,6 +57,7 @@ class SessionEntity private constructor(
             startTime = startTime,
             sessionType = sessionType,
             place = Place.newPlace(address, longitude, latitude, placeName),
+            code = code,
         )
     }
 
@@ -72,6 +76,7 @@ class SessionEntity private constructor(
                     longitude = place.longitude,
                     latitude = place.latitude,
                     placeName = place.name,
+                    code = code,
                 )
             }
         }

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
@@ -7,7 +7,12 @@ import com.depromeet.makers.presentation.restapi.dto.request.CheckInCodeRequest
 import com.depromeet.makers.presentation.restapi.dto.request.GetLocationRequest
 import com.depromeet.makers.presentation.restapi.dto.response.AttendanceResponse
 import com.depromeet.makers.presentation.restapi.dto.response.CheckInStatusResponse
+import com.depromeet.makers.presentation.restapi.dto.response.ErrorResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
@@ -38,7 +43,50 @@ class CheckInController(
             ),
         )
 
-    @Operation(summary = "코드 기반 세션 출석", description = "세션에 출석합니다. (출석 코드를 기반으로 출석 처리)")
+    @Operation(
+        summary = "코드 기반 세션 출석",
+        description = "세션에 출석합니다. (출석 코드를 기반으로 출석 처리)",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "출석 성공",
+                content = [Content(schema = Schema(implementation = AttendanceResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "AT0008",
+                description = "출석 코드가 불일치",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [ExampleObject(
+                            "{\n" +
+                                    "  \"code\": \"AT0008\",\n" +
+                                    "  \"message\": \"출석 코드가 일치하지 않습니다.\",\n" +
+                                    "  \"data\": {\n" +
+                                    "    \"retryCount\": 1\n" +
+                                    "  }\n" +
+                                    "}"
+                        )],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "AT0010",
+                description = "출석 시도 횟수 초과",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [ExampleObject(
+                            "{\n" +
+                                    "  \"code\": \"AT0010\",\n" +
+                                    "  \"message\": \"출석 시도 횟수를 초과하였습니다.\"\n" +
+                                    "}"
+                        )],
+                    ),
+                ],
+            ),
+        ]
+    )
     @PostMapping("/code")
     fun checkInSessionWithCode(
         authentication: Authentication,

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
@@ -1,18 +1,16 @@
 package com.depromeet.makers.presentation.restapi.controller
 
 import com.depromeet.makers.domain.usecase.CheckInSession
+import com.depromeet.makers.domain.usecase.CheckInSessionWithCode
 import com.depromeet.makers.domain.usecase.GetCheckInStatus
+import com.depromeet.makers.presentation.restapi.dto.request.CheckInCodeRequest
 import com.depromeet.makers.presentation.restapi.dto.request.GetLocationRequest
 import com.depromeet.makers.presentation.restapi.dto.response.AttendanceResponse
 import com.depromeet.makers.presentation.restapi.dto.response.CheckInStatusResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.security.core.Authentication
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import java.time.LocalDateTime
 
 @Tag(name = "출석 관리 API", description = "출석 관리 API")
@@ -20,38 +18,52 @@ import java.time.LocalDateTime
 @RequestMapping("/v1/check-in")
 class CheckInController(
     private val checkInSession: CheckInSession,
+    private val checkInSessionWithCode: CheckInSessionWithCode,
     private val getCheckInStatus: GetCheckInStatus,
 ) {
-
     @Operation(summary = "세션 출석", description = "세션에 출석합니다. (서버에서 현재 시간을 기준으로 출석 처리)")
     @PostMapping
     fun checkInSession(
         authentication: Authentication,
         @RequestBody request: GetLocationRequest,
-    ): AttendanceResponse {
-        return AttendanceResponse.fromDomain(
+    ): AttendanceResponse =
+        AttendanceResponse.fromDomain(
             checkInSession.execute(
                 CheckInSession.CheckInSessionInput(
                     now = LocalDateTime.now(),
                     memberId = authentication.name,
                     latitude = request.latitude,
                     longitude = request.longitude,
-                )
-            )
+                ),
+            ),
         )
-    }
+
+    @Operation(summary = "코드 기반 세션 출석", description = "세션에 출석합니다. (출석 코드를 기반으로 출석 처리)")
+    @PostMapping("/code")
+    fun checkInSessionWithCode(
+        authentication: Authentication,
+        @RequestBody request: CheckInCodeRequest,
+    ): AttendanceResponse =
+        AttendanceResponse.fromDomain(
+            checkInSessionWithCode.execute(
+                CheckInSessionWithCode.CheckInSessionWithCodeInput(
+                    memberId = authentication.name,
+                    now = LocalDateTime.now(),
+                    code = request.code,
+                ),
+            ),
+        )
 
     @Operation(summary = "세션 출석 상태", description = "현재 세션 출석 상태 확인합니다. (CheckInStatusResponse 스키마에 자세한 설명있습니다.)")
     @GetMapping
-    fun checkInStatus(
-        authentication: Authentication,
-    ): CheckInStatusResponse {
-        val checkInStatus = getCheckInStatus.execute(
-            GetCheckInStatus.GetCheckInStatusInput(
-                now = LocalDateTime.now(),
-                memberId = authentication.name,
+    fun checkInStatus(authentication: Authentication): CheckInStatusResponse {
+        val checkInStatus =
+            getCheckInStatus.execute(
+                GetCheckInStatus.GetCheckInStatusInput(
+                    now = LocalDateTime.now(),
+                    memberId = authentication.name,
+                ),
             )
-        )
         return CheckInStatusResponse(
             generation = checkInStatus.generation,
             week = checkInStatus.week,

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/CheckInController.kt
@@ -63,7 +63,7 @@ class CheckInController(
                                     "  \"code\": \"AT0008\",\n" +
                                     "  \"message\": \"출석 코드가 일치하지 않습니다.\",\n" +
                                     "  \"data\": {\n" +
-                                    "    \"retryCount\": 1\n" +
+                                    "    \"tryCount\": 1\n" +
                                     "  }\n" +
                                     "}"
                         )],

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/SessionController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/SessionController.kt
@@ -53,7 +53,7 @@ class SessionController(
     @Operation(
         summary = "기수에 따른 모든 주차의 세션들 조회 요청",
         description = "기수에 따른 모든 주차의 세션들을 조회합니다.\n" +
-                "일반 유저의 경우 위도, 경도가 0.0 으로 마스킹되어 반환됩니다."
+                "일반 유저의 경우 위도, 경도가 0.0 으로, code가 null로 마스킹되어 반환됩니다."
     )
     @Parameter(name = "generation", description = "조회할 세션의 기수", example = "15")
     @GetMapping
@@ -76,7 +76,7 @@ class SessionController(
 
     @Operation(
         summary = "세션 정보 조회", description = "세션의 정보를 조회합니다.\n" +
-                "일반 유저의 경우 위도, 경도가 0.0 으로 마스킹되어 반환됩니다."
+                "일반 유저의 경우 위도, 경도가 0.0 으로, code가 null로 마스킹되어 반환됩니다."
     )
     @GetMapping("/info")
     fun getInfoSession(

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/request/GetCheckInCodeRequest.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/request/GetCheckInCodeRequest.kt
@@ -1,0 +1,9 @@
+package com.depromeet.makers.presentation.restapi.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "코드 출석 요청 dto")
+data class CheckInCodeRequest(
+    @Schema(description = "출석 코드", example = "1234")
+    val code: String,
+)

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/GetSessionResponse.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/GetSessionResponse.kt
@@ -29,6 +29,9 @@ class GetSessionResponse(
 
     @Schema(description = "장소", example = "온라인")
     val place: PlaceResponse,
+
+    @Schema(description = "세션 코드 (어드민 role 경우 view)", example = "1234")
+    val code: String?,
 ) {
     companion object {
         fun fromDomain(session: Session) = with(session) {
@@ -41,6 +44,7 @@ class GetSessionResponse(
                 startTime = startTime.toString(),
                 sessionType = sessionType.name,
                 place = place.let { PlaceResponse.fromDomain(it) },
+                code = code,
             )
         }
     }

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/GetSessionsResponse.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/GetSessionsResponse.kt
@@ -36,6 +36,9 @@ data class GetSessionsResponse(
 
         @Schema(description = "장소", example = "온라인")
         val place: PlaceResponse,
+
+        @Schema(description = "세션 코드 (어드민 role 경우 view)", example = "1234")
+        val code: String?,
     ) {
         companion object {
             fun fromDomain(session: Session) = with(session) {
@@ -48,6 +51,7 @@ data class GetSessionsResponse(
                     startTime = startTime.toString(),
                     sessionType = sessionType.name,
                     place = place.let { PlaceResponse.fromDomain(it) },
+                    code = code,
                 )
             }
         }

--- a/src/main/resources/db/migration/V4__add_session_code.sql
+++ b/src/main/resources/db/migration/V4__add_session_code.sql
@@ -1,0 +1,4 @@
+ALTER TABLE session
+    ADD COLUMN code      VARCHAR(4) NULL;
+ALTER TABLE attendances
+    ADD COLUMN try_count INT NULL;

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionWithCodeTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/CheckInSessionWithCodeTest.kt
@@ -1,0 +1,193 @@
+package com.depromeet.makers.domain.usecase
+
+import com.depromeet.makers.domain.exception.InvalidCheckInCodeException
+import com.depromeet.makers.domain.exception.NotSupportedCheckInCodeException
+import com.depromeet.makers.domain.exception.TryCountOverException
+import com.depromeet.makers.domain.gateway.AttendanceGateway
+import com.depromeet.makers.domain.gateway.MemberGateway
+import com.depromeet.makers.domain.gateway.SessionGateway
+import com.depromeet.makers.domain.model.*
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+
+class CheckInSessionWithCodeTest : BehaviorSpec({
+    Given("출석 코드로 오프라인 세션에 참여할 때") {
+        val attendanceGateway = mockk<AttendanceGateway>()
+        val sessionGateway = mockk<SessionGateway>()
+        val memberGateway = mockk<MemberGateway>()
+        val checkInSessionWithCode = CheckInSessionWithCode(attendanceGateway, sessionGateway, memberGateway)
+
+        val mockMemberId = "123e4567-e89b-12d3-a456-426614174000"
+        val mockCode = "1234"
+        val mockNow = LocalDateTime.of(2030, 10, 1, 10, 0)
+        val mockMember = Member(
+            memberId = "123e4567-e89b-12d3-a456-426614174000",
+            name = "홍길동",
+            email = "email@email.com",
+            passCord = "1234",
+            generations = emptySet(),
+        )
+        val mockAttendance = Attendance(
+            attendanceId = "123e4567-e89b-12d3-a456-426614174000",
+            generation = 15,
+            week = 1,
+            member = mockMember,
+            sessionType = SessionType.OFFLINE,
+            attendanceStatus = AttendanceStatus.ATTENDANCE_ON_HOLD,
+            attendanceTime = null,
+            tryCount = 0,
+        )
+        val mockSession = Session(
+            sessionId = mockMemberId,
+            generation = 15,
+            week = 1,
+            title = "세션 제목",
+            description = "세션 설명",
+            startTime = mockNow,
+            sessionType = SessionType.OFFLINE,
+            place = Place.newPlace(
+                address = "서울특별시 강남구 테헤란로 521",
+                longitude = 127.034,
+                latitude = 37.501,
+                name = "장소"
+            ),
+            code = mockCode,
+        )
+
+        every { sessionGateway.findByStartTimeBetween(any(), any()) } returns mockSession
+        every { memberGateway.getById(mockMemberId) } returns mockMember
+        every { attendanceGateway.findByMemberIdAndGenerationAndWeek(mockMemberId, any(), any()) } returns mockAttendance
+        every { attendanceGateway.save(any()) } returns mockAttendance.checkIn(mockNow, AttendanceStatus.ATTENDANCE)
+
+        When("올바른 출석 코드를 입력하면") {
+            val result = checkInSessionWithCode.execute(
+                CheckInSessionWithCode.CheckInSessionWithCodeInput(
+                    mockMemberId,
+                    mockNow,
+                    mockCode,
+                )
+            )
+
+            Then("출석 성공 정보가 반환된다.") {
+                result.attendanceStatus shouldBe AttendanceStatus.ATTENDANCE
+                result.attendanceTime shouldBe mockNow
+            }
+        }
+
+        When("잘못된 출석 코드를 입력하면") {
+            val executor = {
+                checkInSessionWithCode.execute(
+                    CheckInSessionWithCode.CheckInSessionWithCodeInput(
+                        mockMemberId,
+                        mockNow,
+                        "0000",
+                    )
+                )
+            }
+
+            Then("출석 실패 정보가 반환된다.") {
+                shouldThrow<InvalidCheckInCodeException>(executor)
+            }
+        }
+    }
+
+    Given("출석 코드로 온라인 세션에 참여할 때") {
+        val attendanceGateway = mockk<AttendanceGateway>()
+        val sessionGateway = mockk<SessionGateway>()
+        val memberGateway = mockk<MemberGateway>()
+        val checkInSessionWithCode = CheckInSessionWithCode(attendanceGateway, sessionGateway, memberGateway)
+
+        val mockMemberId = "123e4567-e89b-12d3-a456-426614174000"
+        val mockCode = "1234"
+        val mockNow = LocalDateTime.of(2030, 10, 1, 10, 0)
+
+        every { memberGateway.getById(any()) } returns mockk<Member>()
+        every { sessionGateway.findByStartTimeBetween(any(), any()) } returns mockk<Session>() {
+            every { isOnline() } returns true
+        }
+
+        When("출석 요청하면") {
+            val executor = {
+                checkInSessionWithCode.execute(
+                    CheckInSessionWithCode.CheckInSessionWithCodeInput(
+                        mockMemberId,
+                        mockNow,
+                        mockCode,
+                    )
+                )
+            }
+
+            Then("온라인 세션에는 출석할 수 없다.") {
+                shouldThrow<NotSupportedCheckInCodeException>(executor)
+            }
+        }
+    }
+
+    Given("재시도 횟수를 초과하여, 출석 코드로 오프라인 세션에 참여할 때") {
+        val attendanceGateway = mockk<AttendanceGateway>()
+        val sessionGateway = mockk<SessionGateway>()
+        val memberGateway = mockk<MemberGateway>()
+        val checkInSessionWithCode = CheckInSessionWithCode(attendanceGateway, sessionGateway, memberGateway)
+
+        val mockMemberId = "123e4567-e89b-12d3-a456-426614174000"
+        val mockCode = "1234"
+        val mockNow = LocalDateTime.of(2030, 10, 1, 10, 0)
+        val mockMember = Member(
+            memberId = "123e4567-e89b-12d3-a456-426614174000",
+            name = "홍길동",
+            email = "email@email.com",
+            passCord = "1234",
+            generations = emptySet(),
+        )
+        val mockAttendance = Attendance(
+            attendanceId = "123e4567-e89b-12d3-a456-426614174000",
+            generation = 15,
+            week = 1,
+            member = mockMember,
+            sessionType = SessionType.OFFLINE,
+            attendanceStatus = AttendanceStatus.ATTENDANCE_ON_HOLD,
+            attendanceTime = null,
+            tryCount = Attendance.MAX_TRY_COUNT,
+        )
+        val mockSession = Session(
+            sessionId = mockMemberId,
+            generation = 15,
+            week = 1,
+            title = "세션 제목",
+            description = "세션 설명",
+            startTime = mockNow,
+            sessionType = SessionType.OFFLINE,
+            place = Place.newPlace(
+                address = "서울특별시 강남구 테헤란로 521",
+                longitude = 127.034,
+                latitude = 37.501,
+                name = "장소"
+            ),
+            code = mockCode,
+        )
+
+        every { sessionGateway.findByStartTimeBetween(any(), any()) } returns mockSession
+        every { memberGateway.getById(mockMemberId) } returns mockMember
+        every { attendanceGateway.findByMemberIdAndGenerationAndWeek(mockMemberId, any(), any()) } returns mockAttendance
+
+        When("출석 요청하면") {
+            val executor = {
+                checkInSessionWithCode.execute(
+                    CheckInSessionWithCode.CheckInSessionWithCodeInput(
+                        mockMemberId,
+                        mockNow,
+                        "0000",
+                    )
+                )
+            }
+
+            Then("재시도 횟수 초과 예외가 발생한다.") {
+                shouldThrow<TryCountOverException>(executor)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/CreateNewSessionTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/CreateNewSessionTest.kt
@@ -6,7 +6,10 @@ import com.depromeet.makers.domain.model.SessionType
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldBeInteger
 import io.mockk.every
 import io.mockk.mockk
 import java.time.LocalDateTime
@@ -48,6 +51,12 @@ class CreateNewSessionTest : BehaviorSpec({
             Then("세션 정보가 등록된다.") {
                 result.title shouldBeEqual mockTitle
                 result.description shouldBe mockDescription
+            }
+
+            Then("4자리 랜덤 출석 코드가 생성된다.") {
+                result.code shouldNotBe null
+                result.code.shouldBeInteger()
+                result.code!!.length shouldBe 4
             }
         }
 

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/GetInfoSessionTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/GetInfoSessionTest.kt
@@ -29,6 +29,7 @@ class GetInfoSessionTest : BehaviorSpec({
                 latitude = 37.501,
                 name = "장소"
             ),
+            code = "1234",
         )
         every { sessionGateway.findByStartTimeBetween(any(), any()) } returns mockSession
 
@@ -43,6 +44,10 @@ class GetInfoSessionTest : BehaviorSpec({
             Then("위치 정보가 마스킹되어 반환된다") {
                 result.place.longitude shouldBe 0.0
                 result.place.latitude shouldBe 0.0
+            }
+
+            Then("출석 코드가 마스킹되어 반환된다") {
+                result.code shouldBe null
             }
         }
     }
@@ -65,6 +70,7 @@ class GetInfoSessionTest : BehaviorSpec({
                 latitude = 37.501,
                 name = "장소"
             ),
+            code = "1234",
         )
         every { sessionGateway.findByStartTimeBetween(any(), any()) } returns mockSession
 
@@ -79,6 +85,10 @@ class GetInfoSessionTest : BehaviorSpec({
             Then("위치 정보가 마스킹되지 않고 반환된다") {
                 result.place.longitude shouldBe 127.034
                 result.place.latitude shouldBe 37.501
+            }
+
+            Then("출석 코드가 마스킹되지 않고 반환된다") {
+                result.code shouldBe "1234"
             }
         }
     }

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/GetSessionsTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/GetSessionsTest.kt
@@ -25,6 +25,7 @@ class GetSessionsTest : BehaviorSpec({
                 startTime = LocalDateTime.of(2030, 10, 1, 10, 0),
                 sessionType = SessionType.OFFLINE,
                 place = Place.emptyPlace(),
+                code = "1234",
             )
         }.toList().shuffled()
 
@@ -34,7 +35,7 @@ class GetSessionsTest : BehaviorSpec({
             val result = getSessions.execute(
                 GetSessions.GetSessionsInput(
                     generation = 15,
-                    isOrganizer = false
+                    isOrganizer = true
                 )
             )
 

--- a/src/test/kotlin/com/depromeet/makers/domain/usecase/GetSessionsTest.kt
+++ b/src/test/kotlin/com/depromeet/makers/domain/usecase/GetSessionsTest.kt
@@ -67,6 +67,7 @@ class GetSessionsTest : BehaviorSpec({
                     latitude = 37.501,
                     name = "장소"
                 ),
+                code = "1234",
             )
         )
         every { sessionGateway.findAllByGeneration(any()) } returns mockSessionList
@@ -82,6 +83,10 @@ class GetSessionsTest : BehaviorSpec({
             Then("위치 정보가 마스킹되어 반환된다") {
                 result[0].place.longitude shouldBe 0.0
                 result[0].place.latitude shouldBe 0.0
+            }
+
+            Then("코드 정보가 마스킹되어 반환된다") {
+                result[0].code shouldBe null
             }
         }
     }
@@ -105,6 +110,7 @@ class GetSessionsTest : BehaviorSpec({
                     latitude = 37.501,
                     name = "장소"
                 ),
+                code = "1234",
             )
         )
         every { sessionGateway.findAllByGeneration(any()) } returns mockSessionList
@@ -117,9 +123,13 @@ class GetSessionsTest : BehaviorSpec({
                 )
             )
 
-            Then("위치 정보가 마스킹되어 반환된다") {
+            Then("위치 정보가 마스킹되지 않고 반환된다") {
                 result[0].place.longitude shouldBe 127.034
                 result[0].place.latitude shouldBe 37.501
+            }
+
+            Then("코드 정보가 마스킹되지 않고 반환된다") {
+                result[0].code shouldBe "1234"
             }
         }
     }


### PR DESCRIPTION
# 💡 기능 
- 오프라인 세션에 필요한 출석 코드 추가
- 오프라인 세션 출석 로직 추가
  - 출석 실패 케이스 response 스웨거에 추가 (요거 자동으로 넣기엔 조금 작업이 필요하더라구요...)
- 어드민 환경에서 세션 조회 시 출석 코드 응답 추가

# 🔎 기타
- 정책은 아직 확정이 안나서 천천히 머지는 제가할게요!

Close #118 
