### PR TITLE
feat: 토큰 claim에 기수 정보 추가 및 role 세팅 방식 변경

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/domain/model/Member.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/model/Member.kt
@@ -15,6 +15,8 @@ data class Member(
         passCord = passCord
     )
 
+    fun currentRole(generation: Int) = generations.find { it.generationId == generation }?.role ?: MemberRole.GRADUATE
+
     companion object {
         fun newMember(
             name: String,

--- a/src/main/kotlin/com/depromeet/makers/domain/model/MemberRole.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/model/MemberRole.kt
@@ -4,5 +4,6 @@ enum class MemberRole(
     val roleName: String
 ) {
     ORGANIZER("ROLE_ORGANIZER"),
-    MEMBER("ROLE_MEMBER");
+    MEMBER("ROLE_MEMBER"),
+    GRADUATE("ROLE_GRADUATE");
 }

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/gateway/TokenGatewayImpl.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/gateway/TokenGatewayImpl.kt
@@ -3,6 +3,7 @@ package com.depromeet.makers.infrastructure.gateway
 import com.depromeet.makers.domain.gateway.TokenGateway
 import com.depromeet.makers.domain.model.Member
 import com.depromeet.makers.infrastructure.token.JWTTokenProvider
+import com.depromeet.makers.properties.DepromeetProperties
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.stereotype.Component
@@ -10,13 +11,14 @@ import org.springframework.stereotype.Component
 @Component
 class TokenGatewayImpl(
     private val tokenProvider: JWTTokenProvider,
+    private val depromeetProperties: DepromeetProperties,
 ) : TokenGateway {
     override fun generateAccessToken(member: Member): String {
-        val authorities = member.generations.map { SimpleGrantedAuthority(it.role.roleName) }
+        val role = member.currentRole(depromeetProperties.generation)
         val authentication = UsernamePasswordAuthenticationToken(
             member.memberId,
             null,
-            authorities,
+            listOf(SimpleGrantedAuthority(role.roleName)),
         )
         return tokenProvider.generateAccessToken(authentication)
     }


### PR DESCRIPTION
# 💡 기능 
- 엑세스 토큰에 기수 정보 추가
- 기수 별 role 정보가 아닌 현재 기수의 role 정보 인증단에 활용하도록 변경
  - 졸업생 role 정보 추가
# 🔎 기타
close #141 

