### PR TITLE
feat: 토큰 기수 확인 로직 추가 & 로그인 응답 포멧 변경

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/domain/exception/AuthenticationException.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/exception/AuthenticationException.kt
@@ -7,3 +7,4 @@ open class AuthenticationException(
 class AuthenticationTokenNotFoundException : AuthenticationException(ErrorCode.TOKEN_NOT_PROVIDED)
 class AuthenticationTokenNotValidException : AuthenticationException(ErrorCode.TOKEN_NOT_VALID)
 class AuthenticationTokenExpiredException : AuthenticationException(ErrorCode.TOKEN_EXPIRED)
+class AuthenticationTokenGenerationExpiredException : AuthenticationException(ErrorCode.TOKEN_EXPIRED_GENERATION)

--- a/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
@@ -21,6 +21,7 @@ enum class ErrorCode(
     TOKEN_NOT_PROVIDED("AU0001", "인증 토큰이 누락되었습니다."),
     TOKEN_NOT_VALID("AU0002", "인증 토큰 형태가 올바르지 않습니다."),
     TOKEN_EXPIRED("AU0003", "인증 토큰이 만료되었습니다"),
+    TOKEN_EXPIRED_GENERATION("AU004", "인증 토큰의 기수 정보가 만료되었습니다"),
 
     /**
      * 인가(Authorization) 관련 오류

--- a/src/main/kotlin/com/depromeet/makers/infrastructure/token/JWTTokenProvider.kt
+++ b/src/main/kotlin/com/depromeet/makers/infrastructure/token/JWTTokenProvider.kt
@@ -1,6 +1,7 @@
 package com.depromeet.makers.infrastructure.token
 
 import com.depromeet.makers.domain.exception.AuthenticationTokenExpiredException
+import com.depromeet.makers.domain.exception.AuthenticationTokenGenerationExpiredException
 import com.depromeet.makers.domain.exception.AuthenticationTokenNotValidException
 import com.depromeet.makers.properties.DepromeetProperties
 import io.jsonwebtoken.ExpiredJwtException
@@ -69,6 +70,9 @@ class JWTTokenProvider(
         }
         val tokenType = claims.header[TOKEN_TYPE_HEADER_KEY] ?: throw RuntimeException()
         if (tokenType != ACCESS_TOKEN_TYPE_VALUE) throw RuntimeException()
+
+        val generation = claims.header[GENERATION_KEY] ?: throw AuthenticationTokenGenerationExpiredException()
+        if (generation != depromeetProperties.generation) throw AuthenticationTokenGenerationExpiredException()
 
         val userId = claims.payload[USER_ID_CLAIM_KEY] as? String? ?: throw RuntimeException()
         val authorities = claims.payload[AUTHORITIES_CLAIM_KEY]?.toString()

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/AuthController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/controller/AuthController.kt
@@ -10,7 +10,7 @@ import com.depromeet.makers.presentation.restapi.dto.request.MemberLoginRequest
 import com.depromeet.makers.presentation.restapi.dto.request.MemberRefreshTokenRequest
 import com.depromeet.makers.presentation.restapi.dto.response.CheckMemberExistsByEmailResponse
 import com.depromeet.makers.presentation.restapi.dto.response.MemberLoginResponse
-import com.depromeet.makers.presentation.restapi.dto.response.MemberResponse
+import com.depromeet.makers.properties.DepromeetProperties
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/v1/auth")
 class AuthController(
+    private val depromeetProperties: DepromeetProperties,
     private val generateTokenWithEmailAndPassCord: GenerateTokenWithEmailAndPassCord,
     private val generateTokenWithRefreshToken: GenerateTokenWithRefreshToken,
     private val updateDefaultMemberPassCord: UpdateDefaultMemberPassCord,
@@ -49,7 +50,7 @@ class AuthController(
         return MemberLoginResponse(
             accessToken = tokens.accessToken,
             refreshToken = tokens.refreshToken,
-            member = MemberResponse.fromDomain(member)
+            member.currentRole(depromeetProperties.generation)
         )
     }
 
@@ -71,7 +72,7 @@ class AuthController(
         return MemberLoginResponse(
             accessToken = tokens.accessToken,
             refreshToken = tokens.refreshToken,
-            member = MemberResponse.fromDomain(member)
+            member.currentRole(depromeetProperties.generation)
         )
     }
 

--- a/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/MemberLoginResponse.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/restapi/dto/response/MemberLoginResponse.kt
@@ -1,5 +1,6 @@
 package com.depromeet.makers.presentation.restapi.dto.response
 
+import com.depromeet.makers.domain.model.MemberRole
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "로그인 결과 DTO")
@@ -10,6 +11,6 @@ data class MemberLoginResponse(
     @Schema(description = "리프레쉬 토큰")
     val refreshToken: String,
 
-    @Schema(description = "사용자 정보")
-    val member: MemberResponse,
+    @Schema(description = "현재 기수 Role 정보")
+    val currentRole: MemberRole,
 )


### PR DESCRIPTION
# 💡 기능 
- 엑세스 토큰에 기수를 확인하여, 기수가 다를 시 토큰을 만료시키는 로직 추가
- 로그인 응답의 포멧을 변경하여, 현재 로그인된 유저의 role 정보를 내리도록 변경
# 🔎 기타
close #143 

