### PR TITLE
refactor: id class ObjectId로 변경

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/components/JWTTokenProvider.kt
+++ b/src/main/kotlin/com/depromeet/makers/components/JWTTokenProvider.kt
@@ -6,6 +6,7 @@ import com.depromeet.makers.domain.exception.ErrorCode
 import com.depromeet.makers.domain.vo.TokenPair
 import com.depromeet.makers.util.logger
 import io.jsonwebtoken.Jwts
+import org.bson.types.ObjectId
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.authority.SimpleGrantedAuthority
@@ -95,7 +96,7 @@ class JWTTokenProvider(
         )
     }
 
-    fun getMemberIdFromRefreshToken(refreshToken: String): String {
+    fun getMemberIdFromRefreshToken(refreshToken: String): ObjectId {
         val claims = jwtParser.parseEncryptedClaims(refreshToken)
         val tokenType = claims.header[TOKEN_TYPE_HEADER_KEY] ?: run {
             logger.error("Token type not found in header - claims($claims)")
@@ -106,10 +107,10 @@ class JWTTokenProvider(
             throw RuntimeException()
         }
 
-        return claims.payload[USER_ID_CLAIM_KEY] as? String ?: run {
+        return ObjectId(claims.payload[USER_ID_CLAIM_KEY] as? String ?: run {
             logger.error("Cannot parse userId from claims - claims($claims)")
             throw RuntimeException()
-        }
+        })
     }
 
     private fun generateAccessTokenExpiration() = Date(System.currentTimeMillis() + appProperties.token.expiration.access * 1000)

--- a/src/main/kotlin/com/depromeet/makers/domain/Member.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/Member.kt
@@ -17,7 +17,7 @@ class Member(
     companion object {
         fun create(name: String, age: Age): Member {
             return Member(
-                id = null,
+                id = ObjectId(),
                 name = name,
                 age = age,
                 role = MemberRole.USER,

--- a/src/main/kotlin/com/depromeet/makers/domain/Member.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/Member.kt
@@ -2,13 +2,14 @@ package com.depromeet.makers.domain
 
 import com.depromeet.makers.domain.enums.MemberRole
 import com.depromeet.makers.domain.vo.Age
+import org.bson.types.ObjectId
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 
 @Document("member")
 class Member(
     @Id
-    val id: String?,
+    val id: ObjectId,
     val name: String,
     val age: Age,
     val role: MemberRole,

--- a/src/main/kotlin/com/depromeet/makers/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/depromeet/makers/repository/MemberRepository.kt
@@ -1,6 +1,7 @@
 package com.depromeet.makers.repository
 
 import com.depromeet.makers.domain.Member
+import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 
-interface MemberRepository : MongoRepository<Member, String>
+interface MemberRepository : MongoRepository<Member, ObjectId>


### PR DESCRIPTION
# 💡 기능 
- ObjectId로 두고 사용하면 생성 timestamp 등 꺼내서 사용하기 편할 거 같아 지정했습니다.
  - 다만 presentation(swagger)에서는 ObjectId로 두면 문서에서 객체로 보여서 DTO에서는 String 타입을 사용하도록 했습니다.
- ObjectId를 not null로 두고 애플리케이션 레벨에서 id를 할당하도록 했습니다..!
  - ObjectId 생성 로직이 인스턴스 id랑 타임스탬프 + random 조합이라 중복이슈는 없을 것 같아요.
  - 다만 isNew 로직을 정상적으로 못탈텐데 관련된 작업이 아직은 없어 인지만 하면 좋을 것 같아요.
# 🔎 기타


