### PR TITLE
feat: member domain 작성

### DIFF
--- a/src/main/kotlin/com/depromeet/makers/config/WebExceptionHandler.kt
+++ b/src/main/kotlin/com/depromeet/makers/config/WebExceptionHandler.kt
@@ -17,8 +17,8 @@ class WebExceptionHandler {
             return handleUnhandledException(e)
         }
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(ErrorResponse(e.errorCode.code, ""))
+        return ResponseEntity.status(errorCode.httpStatus)
+            .body(ErrorResponse(e.errorCode.code, e.errorCode.message))
     }
 
     @ExceptionHandler

--- a/src/main/kotlin/com/depromeet/makers/domain/Member.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/Member.kt
@@ -1,7 +1,11 @@
 package com.depromeet.makers.domain
 
+import com.depromeet.makers.domain.enums.MemberPosition
 import com.depromeet.makers.domain.enums.MemberRole
-import com.depromeet.makers.domain.vo.Age
+import com.depromeet.makers.domain.enums.MemberStatus
+import com.depromeet.makers.domain.vo.Image
+import com.depromeet.makers.domain.vo.MemberLink
+import com.depromeet.makers.domain.vo.TeamHistory
 import org.bson.types.ObjectId
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
@@ -10,17 +14,43 @@ import org.springframework.data.mongodb.core.mapping.Document
 class Member(
     @Id
     val id: ObjectId,
-    val name: String,
-    val age: Age,
-    val role: MemberRole,
+    var name: String,
+    var email: String,
+    var deviceToken: String?,
+    var description: String?,
+    var position: MemberPosition,
+    var role: MemberRole,
+    var status: MemberStatus,
+    var profileImage: Image?,
+    var teamHistory: List<TeamHistory>,
+    var company: String?,
+    var website: Set<MemberLink>,
+    var skills: Set<String>,
 ) {
     companion object {
-        fun create(name: String, age: Age): Member {
+        fun create(
+            name: String,
+            email: String,
+            deviceToken: String? = null,
+            role: MemberRole = MemberRole.USER,
+            position: MemberPosition,
+            status: MemberStatus,
+            teamHistory: List<TeamHistory>,
+        ): Member {
             return Member(
                 id = ObjectId(),
                 name = name,
-                age = age,
-                role = MemberRole.USER,
+                email = email,
+                deviceToken = deviceToken,
+                description = null,
+                position = position,
+                role = role,
+                status = status,
+                profileImage = null,
+                teamHistory = teamHistory,
+                company = null,
+                website = emptySet(),
+                skills = emptySet(),
             )
         }
     }

--- a/src/main/kotlin/com/depromeet/makers/domain/enums/MemberPosition.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/enums/MemberPosition.kt
@@ -1,0 +1,9 @@
+package com.depromeet.makers.domain.enums
+
+enum class MemberPosition {
+    DESIGN,
+    WEB,
+    ANDROID,
+    IOS,
+    SERVER,
+}

--- a/src/main/kotlin/com/depromeet/makers/domain/enums/MemberStatus.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/enums/MemberStatus.kt
@@ -1,0 +1,7 @@
+package com.depromeet.makers.domain.enums
+
+enum class MemberStatus {
+    REGISTERED,
+    UNREGISTERED,
+    PENDING,
+}

--- a/src/main/kotlin/com/depromeet/makers/domain/enums/Website.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/enums/Website.kt
@@ -1,0 +1,9 @@
+package com.depromeet.makers.domain.enums
+
+enum class Website {
+    GITHUB,
+    BLOG,
+    LINKEDIN,
+    BEHANCE,
+    ETC,
+}

--- a/src/main/kotlin/com/depromeet/makers/domain/enums/WebsiteType.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/enums/WebsiteType.kt
@@ -1,6 +1,6 @@
 package com.depromeet.makers.domain.enums
 
-enum class Website {
+enum class WebsiteType {
     GITHUB,
     BLOG,
     LINKEDIN,

--- a/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
@@ -1,20 +1,24 @@
 package com.depromeet.makers.domain.exception
 
+import org.springframework.http.HttpStatus
+
 enum class ErrorCode(
+    val httpStatus: HttpStatus,
     val code: Int,
     val message: String,
 ) {
-    INTERNAL_ERROR(5000, "알 수 없는 오류가 발생했어요"),
-    NOT_FOUND(4000, "존재하지 않아요"),
-    TOKEN_EXPIRED(4001, "토큰이 만료되었어요"),
-    TOKEN_NOT_FOUND(4002, "토큰이 없어요"),
-    TOKEN_NOT_VALID(4003, "토큰이 유효하지 않아요"),
-    KAKAO_LOGIN_FAILED(4002, "카카오 로그인에 실패했어요"),
-    UNAUTHORIZED(4003, "권한이 없어요"),
-    UNAUTHENTICATED(4004, "인증되지 않았어요"),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "알 수 없는 오류가 발생했어요"),
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, 40000, "존재하지 않아요"),
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "권한이 없어요"),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 40101, "토큰이 없어요"),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 40102, "토큰이 만료되었어요"),
+    TOKEN_NOT_VALID(HttpStatus.UNAUTHORIZED, 40103, "토큰이 유효하지 않아요"),
+    UNAUTHENTICATED(HttpStatus.UNAUTHORIZED, 40104, "인증되지 않았어요"),
     ;
 
     fun isCriticalError(): Boolean {
-        return this.code >= 5000
+        return this.code >= 50000
     }
 }

--- a/src/main/kotlin/com/depromeet/makers/domain/vo/Image.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/vo/Image.kt
@@ -1,0 +1,6 @@
+package com.depromeet.makers.domain.vo
+
+data class Image(
+    val url: String,
+    val revision: Long,
+)

--- a/src/main/kotlin/com/depromeet/makers/domain/vo/MemberLink.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/vo/MemberLink.kt
@@ -1,8 +1,8 @@
 package com.depromeet.makers.domain.vo
 
-import com.depromeet.makers.domain.enums.Website
+import com.depromeet.makers.domain.enums.WebsiteType
 
 data class MemberLink(
-    val website: Website,
+    val website: WebsiteType,
     val link: String,
 )

--- a/src/main/kotlin/com/depromeet/makers/domain/vo/MemberLink.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/vo/MemberLink.kt
@@ -1,0 +1,8 @@
+package com.depromeet.makers.domain.vo
+
+import com.depromeet.makers.domain.enums.Website
+
+data class MemberLink(
+    val website: Website,
+    val link: String,
+)

--- a/src/main/kotlin/com/depromeet/makers/domain/vo/TeamHistory.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/vo/TeamHistory.kt
@@ -1,0 +1,6 @@
+package com.depromeet.makers.domain.vo
+
+data class TeamHistory(
+    val generation: Int,
+    val team: Int?,
+)

--- a/src/main/kotlin/com/depromeet/makers/presentation/web/AuthController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/web/AuthController.kt
@@ -3,6 +3,7 @@ package com.depromeet.makers.presentation.web
 import com.depromeet.makers.presentation.web.dto.request.AppleLoginRequest
 import com.depromeet.makers.presentation.web.dto.request.KakaoLoginRequest
 import com.depromeet.makers.presentation.web.dto.request.RefreshTokenRequest
+import com.depromeet.makers.presentation.web.dto.request.TestLoginRequest
 import com.depromeet.makers.presentation.web.dto.response.AuthenticationResponse
 import com.depromeet.makers.service.AuthService
 import io.swagger.v3.oas.annotations.Operation
@@ -36,8 +37,10 @@ class AuthController(
 
     @Operation(summary = "테스트 로그인", description = "테스트용 로그인을 수행합니다.")
     @PostMapping("/v1/auth/test")
-    fun testLogin(): AuthenticationResponse {
-        val loginResult = authService.testLogin()
+    fun testLogin(
+        @RequestBody testLoginRequest: TestLoginRequest,
+    ): AuthenticationResponse {
+        val loginResult = authService.testLogin(testLoginRequest.externalIdentifier)
         return AuthenticationResponse.from(loginResult)
     }
 

--- a/src/main/kotlin/com/depromeet/makers/presentation/web/dto/request/TestLoginRequest.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/web/dto/request/TestLoginRequest.kt
@@ -1,0 +1,5 @@
+package com.depromeet.makers.presentation.web.dto.request
+
+data class TestLoginRequest(
+    val externalIdentifier: String,
+)

--- a/src/main/kotlin/com/depromeet/makers/service/AuthService.kt
+++ b/src/main/kotlin/com/depromeet/makers/service/AuthService.kt
@@ -5,10 +5,12 @@ import com.depromeet.makers.components.SocialLoginProvider
 import com.depromeet.makers.domain.Member
 import com.depromeet.makers.domain.SocialCredentials
 import com.depromeet.makers.domain.SocialCredentialsKey
+import com.depromeet.makers.domain.enums.MemberPosition
+import com.depromeet.makers.domain.enums.MemberRole
+import com.depromeet.makers.domain.enums.MemberStatus
 import com.depromeet.makers.domain.enums.SocialCredentialsProvider
 import com.depromeet.makers.domain.exception.DomainException
 import com.depromeet.makers.domain.exception.ErrorCode
-import com.depromeet.makers.domain.vo.Age
 import com.depromeet.makers.domain.vo.TokenPair
 import com.depromeet.makers.repository.MemberRepository
 import com.depromeet.makers.repository.SocialCredentialsRepository
@@ -24,10 +26,10 @@ class AuthService(
     private val memberRepository: MemberRepository,
     private val socialCredentialsRepository: SocialCredentialsRepository,
 ) {
-    fun testLogin(): TokenPair {
+    fun testLogin(id: String): TokenPair {
         val socialCredentialsKey = SocialCredentialsKey(
             provider = SocialCredentialsProvider.TEST,
-            externalIdentifier = "test"
+            externalIdentifier = id,
         )
         return loginWithCredential(socialCredentialsKey)
     }
@@ -58,7 +60,15 @@ class AuthService(
 
     private fun loginWithCredential(socialCredentialsKey: SocialCredentialsKey): TokenPair {
         val retrievedMember = socialCredentialsRepository.findByIdOrNull(socialCredentialsKey)?.member ?: run {
-            val newMember = Member.create("", Age(10))
+            val newMember = Member.create(
+                name = "test",
+                email = "test",
+                deviceToken = "test",
+                position = MemberPosition.IOS,
+                role = MemberRole.ADMIN,
+                status = MemberStatus.REGISTERED,
+                teamHistory = emptyList(),
+            )
             memberRepository.save(newMember).also {
                 socialCredentialsRepository.save(SocialCredentials(socialCredentialsKey, it))
             }


### PR DESCRIPTION
# 💡 기능 
- 멤버 도메인 객체를 생성했습니다.
- 에러 응답에 `httpStatus`를 담았습니다.
- 상세 커스텀 에러 코드를 5자리로 늘렸습니다.
  - 404 관련 코드의 경우 `40400 ~ 40499` 까지 쓸 수 있어요.
- 테스트 로그인의 경우 id를 받도록 변경했습니다
# 🔎 기타


