### PR TITLE
feat: 사용자 가입/인증 플로우에 맞게 구현해요

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,11 @@ dependencies {
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
 
+	// 메일 발송
+	implementation("org.springframework.boot:spring-boot-starter-mail")
+	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+	implementation("nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect")
+
 	val jjwtVersion = "0.12.5"
 	implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:$jjwtVersion")

--- a/src/main/kotlin/com/depromeet/makers/components/EmailSender.kt
+++ b/src/main/kotlin/com/depromeet/makers/components/EmailSender.kt
@@ -1,0 +1,33 @@
+package com.depromeet.makers.components
+
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
+import org.springframework.stereotype.Component
+import org.thymeleaf.context.Context
+import org.thymeleaf.spring6.SpringTemplateEngine
+
+@Component
+class EmailSender(
+    private val javaMailSender: JavaMailSender,
+    private val springTemplateEngine: SpringTemplateEngine,
+) {
+    fun sendEmailVerificationMail(request: SendVerificationEmailRequest) {
+        val message = javaMailSender.createMimeMessage()
+        val content = with(Context()) {
+            setVariable("code", request.code)
+            springTemplateEngine.process("email-verification", this)
+        }
+
+        with(MimeMessageHelper(message, false)) {
+            setTo(request.targetEmail)
+            setSubject("[디프만] 회원 인증 메일입니다")
+            setText(content, true)
+            javaMailSender.send(message)
+        }
+    }
+
+    data class SendVerificationEmailRequest(
+        val targetEmail: String,
+        val code: String,
+    )
+}

--- a/src/main/kotlin/com/depromeet/makers/domain/Member.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/Member.kt
@@ -27,6 +27,8 @@ class Member(
     var website: Set<MemberLink>,
     var skills: Set<String>,
 ) {
+    fun isPendingStatus(): Boolean = status == MemberStatus.PENDING
+
     companion object {
         fun create(
             name: String,

--- a/src/main/kotlin/com/depromeet/makers/domain/MemberVerification.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/MemberVerification.kt
@@ -1,0 +1,37 @@
+package com.depromeet.makers.domain
+
+import org.bson.types.ObjectId
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+
+@Document("memberVerification")
+class MemberVerification(
+    @Id
+    val key: MemberVerificationKey,
+    val expiresAt: LocalDateTime,
+) {
+    fun isExpired(): Boolean = expiresAt.isBefore(LocalDateTime.now())
+
+    companion object {
+        private const val VERIFICATION_EXPIRE_MINUTES = 10L
+
+        fun create(
+            memberId: ObjectId,
+            verificationCode: String,
+        ): MemberVerification {
+            return MemberVerification(
+                key = MemberVerificationKey(
+                    memberId = memberId,
+                    verificationCode = verificationCode,
+                ),
+                expiresAt = LocalDateTime.now().plusMinutes(VERIFICATION_EXPIRE_MINUTES),
+            )
+        }
+    }
+}
+
+data class MemberVerificationKey(
+    val memberId: ObjectId,
+    val verificationCode: String,
+)

--- a/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/depromeet/makers/domain/exception/ErrorCode.kt
@@ -10,12 +10,16 @@ enum class ErrorCode(
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "알 수 없는 오류가 발생했어요"),
 
     NOT_FOUND(HttpStatus.NOT_FOUND, 40000, "존재하지 않아요"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, 40001, "잘못된 요청이에요"),
+    VERIFICATION_EXPIRED(HttpStatus.BAD_REQUEST, 40002, "인증 코드가 만료되었어요"),
 
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "권한이 없어요"),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 40101, "토큰이 없어요"),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 40102, "토큰이 만료되었어요"),
     TOKEN_NOT_VALID(HttpStatus.UNAUTHORIZED, 40103, "토큰이 유효하지 않아요"),
     UNAUTHENTICATED(HttpStatus.UNAUTHORIZED, 40104, "인증되지 않았어요"),
+
+    FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "접근 권한이 없어요"),
     ;
 
     fun isCriticalError(): Boolean {

--- a/src/main/kotlin/com/depromeet/makers/presentation/web/AuthController.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/web/AuthController.kt
@@ -1,8 +1,11 @@
 package com.depromeet.makers.presentation.web
 
 import com.depromeet.makers.presentation.web.dto.request.AppleLoginRequest
+import com.depromeet.makers.presentation.web.dto.request.EmailVerifyRequest
 import com.depromeet.makers.presentation.web.dto.request.KakaoLoginRequest
 import com.depromeet.makers.presentation.web.dto.request.RefreshTokenRequest
+import com.depromeet.makers.presentation.web.dto.request.RegisterRequest
+import com.depromeet.makers.presentation.web.dto.request.RegisterWithVerifyRequest
 import com.depromeet.makers.presentation.web.dto.request.TestLoginRequest
 import com.depromeet.makers.presentation.web.dto.response.AuthenticationResponse
 import com.depromeet.makers.service.AuthService
@@ -34,6 +37,33 @@ class AuthController(
         val loginResult = authService.appleLogin(appleLoginRequest.identityToken)
         return AuthenticationResponse.from(loginResult)
     }
+
+    @Operation(summary = "수동 회원 가입", description = "어드민 승인이 필요한 수동 회원가입을 수행합니다.")
+    @PostMapping("/v1/auth/register")
+    fun register(
+        @RequestBody registerRequest: RegisterRequest,
+    ) {
+        authService.register(registerRequest)
+    }
+
+    @Operation(summary = "이메일 인증 기반 회원 가입", description = "이메일 인증을 통한 회원 가입을 수행합니다.")
+    @PostMapping("/v1/auth/verify")
+    fun register(
+        @RequestBody verifyRequest: RegisterWithVerifyRequest,
+    ): AuthenticationResponse {
+        val loginResult = authService.registerWithEmailVerify(verifyRequest)
+        return AuthenticationResponse.from(loginResult)
+    }
+
+    @Operation(summary = "이메일 인증 요청", description = "해당 사용자에 인증 요청을 시도합니다")
+    @PostMapping("/v1/auth/verify-request")
+    fun emailVerify(
+        @RequestBody verifyRequest: EmailVerifyRequest,
+    ) {
+        authService.requestEmailVerification(verifyRequest.memberId)
+    }
+
+
 
     @Operation(summary = "테스트 로그인", description = "테스트용 로그인을 수행합니다.")
     @PostMapping("/v1/auth/test")

--- a/src/main/kotlin/com/depromeet/makers/presentation/web/dto/request/EmailVerifyRequest.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/web/dto/request/EmailVerifyRequest.kt
@@ -1,0 +1,5 @@
+package com.depromeet.makers.presentation.web.dto.request
+
+data class EmailVerifyRequest(
+    val memberId: String,
+)

--- a/src/main/kotlin/com/depromeet/makers/presentation/web/dto/request/RegisterRequest.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/web/dto/request/RegisterRequest.kt
@@ -1,0 +1,16 @@
+package com.depromeet.makers.presentation.web.dto.request
+
+import com.depromeet.makers.domain.enums.MemberPosition
+
+data class RegisterRequest(
+    val name: String,
+    val email: String,
+    val position: MemberPosition,
+
+    val appleLogin: AppleLoginRequest?,
+    val kakaoLogin: KakaoLoginRequest?,
+) {
+    init {
+        require(appleLogin != null || kakaoLogin != null) { "appleLogin or kakaoLogin must be provided" }
+    }
+}

--- a/src/main/kotlin/com/depromeet/makers/presentation/web/dto/request/RegisterWithVerifyRequest.kt
+++ b/src/main/kotlin/com/depromeet/makers/presentation/web/dto/request/RegisterWithVerifyRequest.kt
@@ -1,0 +1,13 @@
+package com.depromeet.makers.presentation.web.dto.request
+
+data class RegisterWithVerifyRequest(
+    val memberId: String,
+    val code: String,
+
+    val appleLogin: AppleLoginRequest?,
+    val kakaoLogin: KakaoLoginRequest?,
+) {
+    init {
+        require(appleLogin != null || kakaoLogin != null) { "appleLogin or kakaoLogin must be provided" }
+    }
+}

--- a/src/main/kotlin/com/depromeet/makers/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/depromeet/makers/repository/MemberRepository.kt
@@ -4,4 +4,6 @@ import com.depromeet.makers.domain.Member
 import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 
-interface MemberRepository : MongoRepository<Member, ObjectId>
+interface MemberRepository : MongoRepository<Member, ObjectId> {
+    fun findFirstByEmail(email: String): Member?
+}

--- a/src/main/kotlin/com/depromeet/makers/repository/MemberVerificationRepository.kt
+++ b/src/main/kotlin/com/depromeet/makers/repository/MemberVerificationRepository.kt
@@ -1,0 +1,8 @@
+package com.depromeet.makers.repository
+
+import com.depromeet.makers.domain.MemberVerification
+import com.depromeet.makers.domain.MemberVerificationKey
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface MemberVerificationRepository : MongoRepository<MemberVerification, MemberVerificationKey> {
+}

--- a/src/main/kotlin/com/depromeet/makers/service/AuthService.kt
+++ b/src/main/kotlin/com/depromeet/makers/service/AuthService.kt
@@ -1,5 +1,6 @@
 package com.depromeet.makers.service
 
+import com.depromeet.makers.components.EmailSender
 import com.depromeet.makers.components.JWTTokenProvider
 import com.depromeet.makers.components.SocialLoginProvider
 import com.depromeet.makers.domain.Member
@@ -33,6 +34,7 @@ class AuthService(
     private val memberRepository: MemberRepository,
     private val memberVerificationRepository: MemberVerificationRepository,
     private val socialCredentialsRepository: SocialCredentialsRepository,
+    private val emailSender: EmailSender,
 ) {
     fun testLogin(id: String): TokenPair {
         val socialCredentialsKey = SocialCredentialsKey(
@@ -150,8 +152,14 @@ class AuthService(
 
         val randomString = StringUtil.generateRandomString(6)
         memberVerificationRepository.save(MemberVerification.create(ObjectId(memberId), randomString))
-        // TODO: 이메일 발송
-        // sendEmail(member.email)
+
+        // 인증 이메일 발송
+        emailSender.sendEmailVerificationMail(
+            EmailSender.SendVerificationEmailRequest(
+                targetEmail = member.email,
+                code = randomString,
+            )
+        )
     }
 
     fun refreshWithRefreshToken(refreshToken: String): TokenPair {

--- a/src/main/kotlin/com/depromeet/makers/service/AuthService.kt
+++ b/src/main/kotlin/com/depromeet/makers/service/AuthService.kt
@@ -3,6 +3,8 @@ package com.depromeet.makers.service
 import com.depromeet.makers.components.JWTTokenProvider
 import com.depromeet.makers.components.SocialLoginProvider
 import com.depromeet.makers.domain.Member
+import com.depromeet.makers.domain.MemberVerification
+import com.depromeet.makers.domain.MemberVerificationKey
 import com.depromeet.makers.domain.SocialCredentials
 import com.depromeet.makers.domain.SocialCredentialsKey
 import com.depromeet.makers.domain.enums.MemberPosition
@@ -12,8 +14,13 @@ import com.depromeet.makers.domain.enums.SocialCredentialsProvider
 import com.depromeet.makers.domain.exception.DomainException
 import com.depromeet.makers.domain.exception.ErrorCode
 import com.depromeet.makers.domain.vo.TokenPair
+import com.depromeet.makers.presentation.web.dto.request.RegisterRequest
+import com.depromeet.makers.presentation.web.dto.request.RegisterWithVerifyRequest
 import com.depromeet.makers.repository.MemberRepository
+import com.depromeet.makers.repository.MemberVerificationRepository
 import com.depromeet.makers.repository.SocialCredentialsRepository
+import com.depromeet.makers.util.StringUtil
+import org.bson.types.ObjectId
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
@@ -24,6 +31,7 @@ class AuthService(
     private val jwtTokenProvider: JWTTokenProvider,
     private val socialLoginProvider: SocialLoginProvider,
     private val memberRepository: MemberRepository,
+    private val memberVerificationRepository: MemberVerificationRepository,
     private val socialCredentialsRepository: SocialCredentialsRepository,
 ) {
     fun testLogin(id: String): TokenPair {
@@ -31,7 +39,10 @@ class AuthService(
             provider = SocialCredentialsProvider.TEST,
             externalIdentifier = id,
         )
-        return loginWithCredential(socialCredentialsKey)
+        return loginWithCredential(
+            socialCredentialsKey = socialCredentialsKey,
+            email = null,
+        )
     }
 
     fun kakaoLogin(accessToken: String): TokenPair {
@@ -40,7 +51,10 @@ class AuthService(
             provider = SocialCredentialsProvider.KAKAO,
             externalIdentifier = kakaoLoginResponse.id.toString(),
         )
-        return loginWithCredential(socialCredentialsKey)
+        return loginWithCredential(
+            socialCredentialsKey = socialCredentialsKey,
+            email = kakaoLoginResponse.kakaoAccount.email,
+        )
     }
 
     fun appleLogin(identityToken: String): TokenPair {
@@ -49,7 +63,95 @@ class AuthService(
             provider = SocialCredentialsProvider.APPLE,
             externalIdentifier = appleId,
         )
-        return loginWithCredential(socialCredentialsKey)
+        return loginWithCredential(
+            socialCredentialsKey = socialCredentialsKey,
+            email = null,
+        )
+    }
+
+    fun register(request: RegisterRequest) {
+        val previousMember = memberRepository.findFirstByEmail(request.email)
+        if (previousMember != null) {
+            // 이미 같은 이메일의 사용자가 존재하는 경우 에러
+            throw DomainException(ErrorCode.BAD_REQUEST)
+        }
+
+        val socialCredentialsKey = when {
+            request.appleLogin != null -> {
+                val appleId = socialLoginProvider.authenticateFromApple(request.appleLogin.identityToken)
+                SocialCredentialsKey(
+                    provider = SocialCredentialsProvider.APPLE,
+                    externalIdentifier = appleId,
+                )
+            }
+            request.kakaoLogin != null -> {
+                val kakaoLoginResponse = socialLoginProvider.authenticateFromKakao(request.kakaoLogin.accessToken)
+                SocialCredentialsKey(
+                    provider = SocialCredentialsProvider.KAKAO,
+                    externalIdentifier = kakaoLoginResponse.id.toString(),
+                )
+            }
+            else -> throw RuntimeException("Cannot be reached")
+        }
+
+        val newMember = Member.create(
+            name = request.name,
+            email = request.email,
+            deviceToken = null,
+            position = request.position,
+            role = MemberRole.USER,
+            status = MemberStatus.PENDING,
+            teamHistory = emptyList(),
+        )
+
+        // 해당 소셜 계정에 대해 계정 매핑
+        memberRepository.save(newMember).also {
+            socialCredentialsRepository.save(SocialCredentials(socialCredentialsKey, newMember))
+        }
+    }
+
+    fun registerWithEmailVerify(request: RegisterWithVerifyRequest): TokenPair {
+        val verification = memberVerificationRepository.findByIdOrNull(
+            MemberVerificationKey(ObjectId(request.memberId), request.code)
+        ) ?: throw DomainException(ErrorCode.NOT_FOUND)
+
+        if (verification.isExpired()) {
+            throw DomainException(ErrorCode.VERIFICATION_EXPIRED)
+        }
+
+        val member = memberRepository.findByIdOrNull(verification.key.memberId)
+            ?: throw DomainException(ErrorCode.NOT_FOUND)
+
+        val socialCredentialsKey = when {
+            request.appleLogin != null -> {
+                val appleId = socialLoginProvider.authenticateFromApple(request.appleLogin.identityToken)
+                SocialCredentialsKey(
+                    provider = SocialCredentialsProvider.APPLE,
+                    externalIdentifier = appleId,
+                )
+            }
+            request.kakaoLogin != null -> {
+                val kakaoLoginResponse = socialLoginProvider.authenticateFromKakao(request.kakaoLogin.accessToken)
+                SocialCredentialsKey(
+                    provider = SocialCredentialsProvider.KAKAO,
+                    externalIdentifier = kakaoLoginResponse.id.toString(),
+                )
+            }
+            else -> throw RuntimeException("Cannot be reached")
+        }
+
+        // 기존 사용자 소셜 매핑에 계정 추가 매핑
+        socialCredentialsRepository.save(SocialCredentials(socialCredentialsKey, member))
+        return generateTokenFromMember(member)
+    }
+
+    fun requestEmailVerification(memberId: String) {
+        val member = memberRepository.findByIdOrNull(ObjectId(memberId)) ?: throw DomainException(ErrorCode.NOT_FOUND)
+
+        val randomString = StringUtil.generateRandomString(6)
+        memberVerificationRepository.save(MemberVerification.create(ObjectId(memberId), randomString))
+        // TODO: 이메일 발송
+        // sendEmail(member.email)
     }
 
     fun refreshWithRefreshToken(refreshToken: String): TokenPair {
@@ -58,21 +160,26 @@ class AuthService(
         return generateTokenFromMember(member)
     }
 
-    private fun loginWithCredential(socialCredentialsKey: SocialCredentialsKey): TokenPair {
+    private fun loginWithCredential(socialCredentialsKey: SocialCredentialsKey, email: String?): TokenPair {
+        // 유저 정보 확인
         val retrievedMember = socialCredentialsRepository.findByIdOrNull(socialCredentialsKey)?.member ?: run {
-            val newMember = Member.create(
-                name = "test",
-                email = "test",
-                deviceToken = "test",
-                position = MemberPosition.IOS,
-                role = MemberRole.ADMIN,
-                status = MemberStatus.REGISTERED,
-                teamHistory = emptyList(),
-            )
-            memberRepository.save(newMember).also {
-                socialCredentialsRepository.save(SocialCredentials(socialCredentialsKey, it))
+            // 이메일 있으면 가입 처리, 그외 미가입 유저 (NOT_FOUND)
+            if (email == null) {
+                throw DomainException(ErrorCode.NOT_FOUND)
             }
+
+            val previousMember = memberRepository.findFirstByEmail(email) ?: throw DomainException(ErrorCode.NOT_FOUND)
+
+            // 기가입자일 경우 소셜 계정 링크
+            socialCredentialsRepository.save(SocialCredentials(socialCredentialsKey, previousMember))
+            return@run previousMember
         }
+
+        // 가입 대기인 경우 에러
+        if (retrievedMember.isPendingStatus()) {
+            throw DomainException(ErrorCode.FORBIDDEN)
+        }
+
         return generateTokenFromMember(retrievedMember)
     }
 

--- a/src/main/kotlin/com/depromeet/makers/util/StringUtil.kt
+++ b/src/main/kotlin/com/depromeet/makers/util/StringUtil.kt
@@ -1,0 +1,11 @@
+package com.depromeet.makers.util
+
+object StringUtil {
+    fun generateRandomString(length: Int): String {
+        val charPool : List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+        return (1..length)
+            .map { kotlin.random.Random.nextInt(0, charPool.size) }
+            .map(charPool::get)
+            .joinToString("")
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,17 @@
 spring:
   application:
     name: depromeet-makers-be
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${SMTP_USERNAME}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
   data:
     mongodb:
       host: ${MONGO_HOST}

--- a/src/main/resources/templates/email-verification.html
+++ b/src/main/resources/templates/email-verification.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<div>
+    <h3>디프만 회원가입 인증 코드 입니다.</h3>
+    <div th:text="${code}"> </div>
+</div>
+
+</body>


### PR DESCRIPTION
# 💡 기능 
![image](https://github.com/user-attachments/assets/e9df65d6-cb58-4fca-82aa-612cf8463beb)
위 사진에 맞게 로직/API를 구현하였어요.

이메일 컨텐츠는 우선 코드만 담게 간단하게 만들어두었고, 추후 메시지와 콘텐츠는 조금 더 다듬어야할 것 같아요

# 🔎 기타


